### PR TITLE
Add installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,3 +9,8 @@ years. That's fine, and you're welcome to do so for other Python community
 projects if you so choose, but please keep in mind that in doing so you're also
 choosing to accept some of the responsibility for maintaining that collective
 trust.
+
+To use the theme either clone it directly with `git`, or else install it
+into your docs build environment via `pip`:
+
+    pip install git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme


### PR DESCRIPTION
While the name *has* been reserved on PyPI, I'm not sure it actually
makes sense to publish the theme that way, so these instructions
just recommend installing it directly from `git`.