### PR TITLE
make the search button wider

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -29,7 +29,7 @@ form.inline-search input {
     display: inline;
 }
 form.inline-search input[type="submit"] {
-    width: 30px;
+    width: 40px;
 }
 
 div.sphinxsidebar {


### PR DESCRIPTION
when the word "Go" translated to "查找" in Chinese, this button seems too narrow.
See example on https://zhsj.github.io/python-docs-zh-cn/