### PR TITLE
Change the font-family for the parameters of a function

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -192,3 +192,6 @@ div.footer a:hover {
     background: none !important;
 }
 
+dl > dt span ~ em {
+    font-family: monospace, sans-serif;
+}


### PR DESCRIPTION
Change the font-family for the parameters of a function.

It's related to this issue: https://bugs.python.org/issue35986