### PR TITLE
Reintroduce copybutton to all code examples

### DIFF
--- a/python_docs_theme/static/copybutton.js
+++ b/python_docs_theme/static/copybutton.js
@@ -3,7 +3,9 @@ $(document).ready(function() {
      * the >>> and ... prompts and the output and thus make the code
      * copyable. */
     var div = $('.highlight-python .highlight,' +
-                '.highlight-python3 .highlight')
+                '.highlight-python3 .highlight,' +
+                '.highlight-pycon .highlight,' +
+                '.highlight-default .highlight');
     var pre = div.find('pre');
 
     // get the styles from the current theme


### PR DESCRIPTION
Many code examples on the official Python documentation do not have a `>>>` copy button. For example, the code snippets in the current [collections][py37-collections] module. Those examples were excluded since Sphinx assigns a different highlight language to those code-blocks.

In the past, Sphinx used `python3` to highlight all the doctest and malformed code blocks (started with `:` instead of `::`). Those blockes had the `highlight-python3` CSS class in the generated HTML. For example, see the [collections][py33-collections] module in Python 3.3. 

However, with the recent change in Sphinx (sphinx-doc/sphinx#4137), the doctest blocks are highlighted by `pycon`, and malformed blocks become `default` for unknown reason. Therefore, those blocks are not captured by `copybutton.js` due to a different CSS class name. There are in total 185 doctests and 382 malformed(?) code blocks highlighted by `pycon` and `default` language in the latest Python official documentation. Note that the [`default` language](https://www.sphinx-doc.org/en/1.8/usage/restructuredtext/directives.html#code-examples) has a similar behavior to `python3`.

This pull request lets code blocks of two additional languages (`pycon` and `default`) to add the copybutton.

[py37-collections]: https://docs.python.org/3.7/library/collections.html
[py33-collections]: https://docs.python.org/3.3/library/collections.html

<details>
<summary>All occurrences of hightlight-pycon in current Python master:</summary>
<pre>
install/index.html:1
faq/windows.html:2
faq/extending.html:2
faq/programming.html:2
whatsnew/3.2.html:1
whatsnew/2.7.html:11
extending/embedding.html:1
extending/extending.html:1
extending/newtypes_tutorial.html:5
library/shlex.html:1
library/re.html:4
library/urllib.parse.html:2
library/multiprocessing.html:7
howto/sorting.html:1
howto/logging-cookbook.html:2
library/turtle.html:72
library/decimal.html:12
library/unittest.mock.html:4
library/http.cookies.html:1
library/statistics.html:19
library/secrets.html:3
library/ssl.html:1
library/email.compat32-message.html:2
library/email.policy.html:1
library/traceback.html:1
library/collections.html:7
library/email.message.html:2
library/datetime.html:2
library/difflib.html:1
library/email.iterators.html:1
library/configparser.html:13
</pre>
</details>

<details>
<summary>All occurrences of hightlight-default in current Python master:</summary>
<pre>
tutorial/floatingpoint.html:1
faq/programming.html:8
whatsnew/3.2.html:32
whatsnew/2.7.html:2
library/getopt.html:2
library/shlex.html:3
library/hashlib.html:10
library/re.html:3
library/unicodedata.html:1
library/urllib.parse.html:3
library/functions.html:10
library/weakref.html:6
library/base64.html:1
library/ftplib.html:1
library/reprlib.html:1
library/turtle.html:3
library/inspect.html:1
library/pprint.html:4
library/operator.html:5
library/unittest.mock-examples.html:55
library/decimal.html:23
library/unittest.mock.html:72
library/copyreg.html:1
library/ssl.html:3
library/time.html:1
library/fractions.html:3
library/functools.html:1
library/ipaddress.html:19
library/pathlib.html:2
library/fnmatch.html:1
library/collections.html:18
library/stdtypes.html:12
library/datetime.html:10
library/difflib.html:17
library/nntplib.html:6
howto/ipaddress.html:3
howto/functional.html:15
howto/sorting.html:22
reference/lexical_analysis.html:1
</pre>
</details>