### PR TITLE
Make copybutton messages translatable

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -57,4 +57,11 @@
 
     {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
     </div>
+    {# Translated messages used by copybutton #}
+    {% if builder != "htmlhelp" and not embedded %}
+    <div class="copybutton-msg" style="display: none">
+        <p id="copybutton-hide-text">{% trans %}Hide the prompts and output{% endtrans %}</p>
+        <p id="copybutton-show-text">{% trans %}Show the prompts and output{% endtrans %}</p>
+    </div>
+    {% endif %}
 {% endblock %}

--- a/python_docs_theme/static/copybutton.js
+++ b/python_docs_theme/static/copybutton.js
@@ -8,10 +8,14 @@ $(document).ready(function() {
                 '.highlight-default .highlight');
     var pre = div.find('pre');
 
+    // search for the translated prompt strings and fallback to use English if not found
+    var hide_text_p = $('#copybutton-hide-text');
+    var hide_text = hide_text_p.length > 0 ? hide_text_p.text() : "Hide the prompts and output";
+    var show_text_p = $('#copybutton-show-text');
+    var show_text = show_text_p.length > 0 ? show_text_p.text() : "Show the prompts and output";
+
     // get the styles from the current theme
     pre.parent().parent().css('position', 'relative');
-    var hide_text = 'Hide the prompts and output';
-    var show_text = 'Show the prompts and output';
     var border_width = pre.css('border-top-width');
     var border_style = pre.css('border-top-style');
     var border_color = pre.css('border-top-color');


### PR DESCRIPTION
This PR implements #23 which make the messages of copybutton (`>>>`) translatable.

When I tested my change using the master branch of Python (branch 3.7 doesn't seem to use python-docs-theme), I couldn't get it read my modified `layout.html`. However, if I manually introduced the change, the pot files would include the new strings and the translation worked.

I think it is better to have someone more familiar with the project structure of PEP 545 to test my implementation before it is merged.