### PR TITLE
[WIP] Add warning about old versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,3 +13,31 @@ trust.
 To use the theme, install it into your docs build environment via ``pip``::
 
     pip install python-docs-theme
+
+
+Features
+========
+
+Outdated redirection
+--------------------
+
+You can define the ``outdated_message`` and ``outdated_link_text``
+variables to show a red banner on each page redirecting to the "latest"
+version.
+
+The ``outdated_message`` comes first, the ``outdated_link_text`` comes
+afterwards and is the one user can click. When clicking on
+``outdated_link_text``, they will be redirected to the same page
+stripped from any prefix.
+
+Meaning if they're on ``/2.7/``, they'll go to ``/``, if they're on
+``/2.7/tutorial/`` they'll go to ``/tutorial/``.
+
+Sadly it also mean that if you're on ``/fr/3.7/c-api/`` you'll be
+redirected to ``/c-api/``, but as we don't know your URL patterns we
+can't really do better.
+
+You can personalize the URL by redefining the ``outdated_href`` block,
+by default it contains::
+
+    /{{ pagename }}{{ file_suffix }}

--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -1,15 +1,13 @@
 {% extends "classic/layout.html" %}
 
 {% block header %}
-<style>
-#outdated-warning {
-    background-color: #FFBABA;
-    color: #6A0E0E;
-}
-</style>
-  <div id="outdated-warning" class="doc-floating-warning">
-  This document is for a version of Python that is no longer supported. Please upgrade to a newer release!
+{%- if outdated is defined %}
+<div id="outdated-warning" class="doc-floating-warning">
+    This document is for an old version of Python that is no longer supported.
+    You should upgrade, and read the
+    <a href="{{ "/" + language if language and language != "en" else "" }}/3/{{ pagename }}{{ file_suffix }}">Python documentation for the last stable release</a>.
 </div>
+{%- endif %}
 {% endblock %}
 
 {% block rootrellink %}

--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -1,11 +1,10 @@
 {% extends "classic/layout.html" %}
 
 {% block header %}
-{%- if outdated is defined %}
+{%- if outdated_message is defined and outdated_link_text is defined %}
 <div id="outdated-warning" class="doc-floating-warning">
-    This document is for an old version of Python that is no longer supported.
-    You should upgrade, and read the
-    <a href="{{ "/" + language if language and language != "en" else "" }}/3/{{ pagename }}{{ file_suffix }}">Python documentation for the last stable release</a>.
+    {{ outdated_message }}
+    <a href="{% block outdated_href %}/{{ pagename }}{{ file_suffix }}{% endblock %}">{{ outdated_link_text }}</a>.
 </div>
 {%- endif %}
 {% endblock %}

--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -1,5 +1,17 @@
 {% extends "classic/layout.html" %}
 
+{% block header %}
+<style>
+#outdated-warning {
+    background-color: #FFBABA;
+    color: #6A0E0E;
+}
+</style>
+  <div id="outdated-warning" class="doc-floating-warning">
+  This document is for a version of Python that is no longer supported. Please upgrade to a newer release!
+</div>
+{% endblock %}
+
 {% block rootrellink %}
     <li><img src="{{ pathto('_static/' + theme_root_icon, 1) }}" alt=""
              style="vertical-align: middle; margin-top: -1px"/></li>

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -195,3 +195,10 @@ div.footer a:hover {
 dl > dt span ~ em {
     font-family: monospace, sans-serif;
 }
+
+#outdated-warning {
+    padding: .5em;
+    text-align: center;
+    background-color: #FFBABA;
+    color: #6A0E0E;
+}


### PR DESCRIPTION
This is a draft on how we could provide a link to newer versions:

![deprecated](https://user-images.githubusercontent.com/239510/57394952-1ff39b00-71c7-11e9-8edd-be03a70b376a.png)

Co-Authored-By: @matrixise 

It lacks a few little things:

- I have not tested it yet, my laptop here is too slow to build multiple languages
- I think that over the pure html link (good for SEO) we could add a layer of javascript to test the existence of the target page and fallbacking to `/` instead of linking to a 404.