### PR TITLE
Removing border radius on a white-on-white box.

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -133,10 +133,6 @@ div.body tt.xref, div.body a tt, div.body code.xref, div.body a code {
     font-weight: normal;
 }
 
-.deprecated {
-    border-radius: 3px;
-}
-
 table.docutils {
     border: 1px solid #ddd;
     min-width: 20%;


### PR DESCRIPTION
It would probably be nice to check the whole file for unused things, but I'm not fluent in CSS, I just spotted this one is probably useless as it's rendered as white over white, so radius or not, it looks the same.