### PR TITLE
Add license information to footer

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -49,7 +49,7 @@
     <br />
     {% trans %}This page is licensed under the Python Software Fundation License Version 2.{% endtrans %}
     <br />
-    {% trans %}Any code contained in this page is additionally licensed under the Zero Clause BSD License.{% endtrans %}
+    {% trans %}Examples, recipes, and other code in the documentation are additionally licensed under the Zero Clause BSD License.{% endtrans %}
     <br />
     {% trans pathto_license=license_file %}See <a href="{{ license_file }}">History and License</a> for more information.{% endtrans %}
     <br /><br />

--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -47,6 +47,12 @@
     <div class="footer">
     &copy; <a href="{{ pathto('copyright') }}">{% trans %}Copyright{% endtrans %}</a> {{ copyright|e }}.
     <br />
+    {% trans %}This page is licensed under the Python Software Fundation License Version 2.{% endtrans %}
+    <br />
+    {% trans %}Any code contained in this page is additionally licensed under the Zero Clause BSD License.{% endtrans %}
+    <br />
+    {% trans pathto_license=license_file %}See <a href="{{ license_file }}">History and License</a> for more information.{% endtrans %}
+    <br /><br />
 
     {% include "footerdonate.html" %}
     <br />


### PR DESCRIPTION
**NOTE** Please do *not* accept this pull request.  It needs to be discussed and approved by the PSF board. **UPDATE:** That's been approved (at last).

This pull request adds license information to the footer of the documentation, including a bit about the license of any code in the documentation being under the [BSD zero clause](https://spdx.org/licenses/0BSD.html) license.  This pull request is meant to accompany python/cpython#17635 and will not work without it.  Please see that pull request for more information.