### PR TITLE
Fix typo in footer.

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -47,7 +47,7 @@
     <div class="footer">
     &copy; <a href="{{ pathto('copyright') }}">{% trans %}Copyright{% endtrans %}</a> {{ copyright|e }}.
     <br />
-    {% trans %}This page is licensed under the Python Software Fundation License Version 2.{% endtrans %}
+    {% trans %}This page is licensed under the Python Software Foundation License Version 2.{% endtrans %}
     <br />
     {% trans %}Examples, recipes, and other code in the documentation are additionally licensed under the Zero Clause BSD License.{% endtrans %}
     <br />


### PR DESCRIPTION
The new footer wording introduced in #36 has typo'd `Foundation`

I am sure it is supposed to say:

> This page is licensed under the Python Software Foundation License Version 2.

and not:

> This page is licensed under the Python Software **Fundation** License Version 2.

(emphasis mine)