### PR TITLE
Fix hyphenation in Chrome

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -57,7 +57,7 @@ div.sphinxsidebar a:hover {
 
 form.inline-search input,
 div.sphinxsidebar input {
-    font-family: 'Lucida Grande',Arial,sans-serif;
+    font-family: Arial,sans-serif;
     border: 1px solid #999999;
     font-size: smaller;
     border-radius: 3px;

--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -4,8 +4,8 @@ stylesheet = pydoctheme.css
 pygments_style = sphinx
 
 [options]
-bodyfont = 'Lucida Grande', Arial, sans-serif
-headfont = 'Lucida Grande', Arial, sans-serif
+bodyfont = Arial, sans-serif
+headfont = Arial, sans-serif
 footerbgcolor = white
 footertextcolor = #555555
 relbarbgcolor = white


### PR DESCRIPTION
There's a [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1029214) or [two](https://bugs.chromium.org/p/chromium/issues/detail?id=1022011) in Chromium (e.g. Chrome, Opera) such that the Lucida Grande font doesn't hyphenate properly (with `hyphens: auto`) which makes things harder to read.

This shows up on macOS, which has this this font, but not on Android or Windows, which use the fallback Arial. Firefox and Safari are okay.

This affects at least [docs.python.org](https://docs.python.org/3.10/tutorial/index.html) and [pip.pypa.io](https://pip.pypa.io/en/stable/development/release-process/), and both use this theme.

# Before

Here's an example from https://pip.pypa.io/en/stable/development/release-process/ in newest Chrome 85 on macOS Mojave:

![docs1](https://user-images.githubusercontent.com/1324225/93298503-fce5ec00-f7fb-11ea-8080-ef977804287b.png)

*(Created with `sphinx-quickstart` using the defaults, changing `html_theme = 'alabaster'` to `'python_docs_theme'`, putting some pip text in `index.rst` and running `rm -rf _build; make html`: [sphinx-test2.zip](https://github.com/python/python-docs-theme/files/5230007/sphinx-test2.zip).)*


# After

This PR suggests to ditch Lucida Grande, at least until when and if the Chrome bug is fixed and widely deployed. This would also make it consistently use Arial as on non-Macs:

![docs2](https://user-images.githubusercontent.com/1324225/93298736-6fef6280-f7fc-11ea-93a9-3d55eb269832.png)

---

See also my original PR at https://github.com/pypa/pip/pull/8879 to disable `hyphens: auto`, but they'd prefer to fix the upstream theme.
