### PR TITLE
Fix codebgcolor and codetextcolor for Sphinx 3.1.0+

### DIFF
--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -21,6 +21,8 @@ visitedlinkcolor = #00608f
 headtextcolor = #1a1a1a
 headbgcolor = white
 headlinkcolor = #aaaaaa
+codebgcolor = #eeffcc
+codetextcolor = #333333
 
 issues_url = 
 root_name = Python


### PR DESCRIPTION
Sphinx 3.1.0+ dropped the custom `codebgcolor` and `codetextcolor` from the classic theme (see commit https://github.com/sphinx-doc/sphinx/commit/b345acc2840a792162845e3a1a3456c347fac08e), leaving pre elements uncolored.

Without the fix:

<img width="815" alt="Screen Shot 2020-10-10 at 11 14 05 AM" src="https://user-images.githubusercontent.com/4149852/95644512-b8dbc380-0ae9-11eb-8dcd-05ccacf91914.png">

Should be:

<img width="811" alt="Screen Shot 2020-10-10 at 11 15 19 AM" src="https://user-images.githubusercontent.com/4149852/95644537-e45eae00-0ae9-11eb-874f-feeb15332eb5.png">
