### PR TITLE
Use default pygments theme

### DIFF
--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -1,7 +1,7 @@
 [theme]
 inherit = default
 stylesheet = pydoctheme.css
-pygments_style = sphinx
+pygments_style = default
 
 [options]
 bodyfont = 'Lucida Grande', Arial, sans-serif


### PR DESCRIPTION
The default theme looks a lot better than the default theme with the green background.