### PR TITLE
Use Python 3.8 for the Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: clone docsbuild scripts
         run: |
           git clone https://github.com/python/docsbuild-scripts/


### PR DESCRIPTION
3.8 is the last security fix...