### PR TITLE
Fix the appearance of version/language selects

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -235,6 +235,14 @@ dl > dt span ~ em {
     div.body h3, div.body h4, div.body h5 {
         font-size: 1rem;
     }
+    /* Override default styles to make more readable */
+    div.body ul {
+        padding-inline-start: 1rem;
+    }
+    div.body blockquote {
+        margin-inline-start: 1rem;
+        margin-inline-end: 0;
+    }
     /* Remove sidebar and top related bar */
     div.related, .sphinxsidebar {
         display: none;
@@ -266,6 +274,7 @@ dl > dt span ~ em {
         top: 0;
         height: 40px;
         width: 100%;
+        max-width: 100vw;
         padding: 0 1rem 0 45px;
         display: flex;
         align-items: center;
@@ -285,7 +294,6 @@ dl > dt span ~ em {
         margin-right: 1rem;
     }
     .version_switcher_placeholder select {
-        height: 30px;
         border-radius: 0;
     }
     .nav-content .search {

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -293,9 +293,6 @@ dl > dt span ~ em {
         flex: 0 1 0;
         margin-right: 1rem;
     }
-    .version_switcher_placeholder select {
-        border-radius: 0;
-    }
     .nav-content .search {
         display: flex;
         flex: 1 1 auto;
@@ -319,10 +316,17 @@ dl > dt span ~ em {
     }
     .nav-content .search input[type=submit] {
         height: 100%;
-        border: 0;
+        appearance: none;
+        -webkit-appearance: none;
+        border: 1px solid-transparent;
+        border-left-color: #a9a9a9;
         box-shadow: none;
-        outline: 1px solid #999;
         cursor: pointer;
+        background-color: #f0f0f0;
+        margin-right: 0;
+    }
+    .nav-content .search input[type=submit]:hover {
+        border-color: #a9a9a9;
     }
     .nav-content .search svg {
         flex: 0 0 20px;
@@ -483,6 +487,7 @@ dl > dt span ~ em {
         appearance: none;
         border: 0;
         height: 100%;
+        background-color: white;
     }
     .language_switcher_placeholder:focus-visible,
     .version_switcher_placeholder:focus-visible {

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -454,6 +454,7 @@ dl > dt span ~ em {
         position: relative;
         border: 1px solid #a8a8a8;
         height: 30px;
+        padding-right: 7px;
     }
     .language_switcher_placeholder {
         margin-top: 2rem;
@@ -465,14 +466,19 @@ dl > dt span ~ em {
         top: 7px;
         width: 15px;
         height: 15px;
-        right: 3px;
+        right: 0;
         pointer-events: none;
     }
     .language_switcher_placeholder select,
     .version_switcher_placeholder select {
+        -webkit-appearance: none;
         appearance: none;
         border: 0;
         height: 100%;
+    }
+    .language_switcher_placeholder:focus-visible,
+    .version_switcher_placeholder:focus-visible {
+        outline-offset: 5px;
     }
     .language_switcher_placeholder select {
         width: 100%;

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -318,7 +318,7 @@ dl > dt span ~ em {
         height: 100%;
         appearance: none;
         -webkit-appearance: none;
-        border: 1px solid-transparent;
+        border: 1px solid transparent;
         border-left-color: #a9a9a9;
         box-shadow: none;
         cursor: pointer;


### PR DESCRIPTION
This PR fixes several issues in the appearance of version and language selects in Safari and Android Chrome. 

On narrow screens, the theme overrides the native appearance of selects to make them look the same in all browsers. However, the non-prefixed `appearance: none` doesn't work in Safari and Chrome for Android, so I added the `-webkit` prefix.

I also added right padding to the version switcher to fix the overlapping of the arrow and the version number when the version number is long.

When clicking the select or focusing on it using tab, user can see an outline. Currently, it goes around the select itself, not the outer div, and looks like it's inside the box. I added the outline-offset to fix this.