### PR TITLE
Remove id searchbox on mobile to fix a layout bug

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -90,7 +90,7 @@
          </a>
         <div class="version_switcher_placeholder"></div>
         {%- if pagename != "search" and builder != "singlehtml" %}
-        <form id="searchbox" role="search" class="search" action="{{ pathto('search') }}" method="get">
+        <form role="search" class="search" action="{{ pathto('search') }}" method="get">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" class="search-icon">
                 <path fill-rule="nonzero"
                         d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 001.48-5.34c-.47-2.78-2.79-5-5.59-5.34a6.505 6.505 0 00-7.27 7.27c.34 2.8 2.56 5.12 5.34 5.59a6.5 6.5 0 005.34-1.48l.27.28v.79l4.25 4.25c.41.41 1.08.41 1.49 0 .41-.41.41-1.08 0-1.49L15.5 14zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" fill="#444"></path>


### PR DESCRIPTION
Sphinx in `doctools.js` uses an element with id `searchbox` to append a paragraph saying "Hide search matches". It is currently not used in the Python docs, but with the responsive theme, it breaks the layout. The search box at the top has a "Hide search matches" link to the right of it:

<img width="502" alt="Screen Shot 2021-05-09 at 12 03 48 PM" src="https://user-images.githubusercontent.com/15233243/117566319-b01e9080-b0be-11eb-8b46-187495142f5a.png">

To reproduce:
1. Go to the 3.11 version of the docs
2. Narrow your screen to mobile width
3. Search for something (eg. "xml rpc")
4. Click on one of the search results (eg. "xmlrpc.client — XML-RPC client access")

I removed the id from the search form in the top menu bar so that this link is not added.