### PR TITLE
Improve readability

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -90,10 +90,10 @@ div.body {
     padding: 0 0 0 1.2em;
 }
 
-div.body p {
-    line-height: 140%;
+div.body p, div.body dd, div.body li, div.body blockquote {
+    text-align: left;
+    line-height: 1.4;
 }
-
 div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6 {
     margin: 0;
     border: 0;

--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -1,6 +1,6 @@
 [theme]
 inherit = default
-stylesheet = pydoctheme.css
+stylesheet = pydoctheme.css?2021.5.dev
 pygments_style = default
 
 [options]


### PR DESCRIPTION
Fixes #77

Replace `text-align: justify` from the classic.css with `text-align: left`
Set line-height to 1.4 instead of 130% for some elements