### PR TITLE
Exclude the floating navbar from CHM help.

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -78,6 +78,7 @@
 
 {%- block body_tag %}
 {{ super() }}
+{%- if builder != 'htmlhelp' %}
 <div class="mobile-nav">
     <input type="checkbox" id="menuToggler" class="toggler__input" aria-controls="navigation"
            aria-pressed="false" aria-expanded="false" role="button" aria-label="{{ _('Menu')}}" />
@@ -116,6 +117,7 @@
         </nav>
     </div>
 </div>
+{% endif -%}
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
I could not get the CHM to build correctly; there was a problem with a CSS file, I think. From the generated HTML, it looks like this is correctly getting rid of the nav bar.

Fixes #83.