### PR TITLE
Bugfix: quote monospace font

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -208,7 +208,7 @@ div.footer a:hover {
 }
 
 dl > dt span ~ em {
-    font-family: monospace, sans-serif;
+    font-family: "monospace", sans-serif;
 }
 
 .toctree-wrapper ul {

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -136,7 +136,7 @@ div.body a:hover {
 }
 
 tt, code, pre {
-    font-family: monospace, sans-serif;
+    font-family: "monospace", sans-serif;
     font-size: 96.5%;
 }
 


### PR DESCRIPTION
For some reason, saying just `monospace` here doesn't seem to work on chrome mobile. Quoting monospace fixes the issue.

Before:
<img src="https://user-images.githubusercontent.com/43412083/136368744-75a22461-c315-4e03-8491-b8fe46faad38.png" width=250>

After:
<img src="https://user-images.githubusercontent.com/43412083/136368764-c64740d8-1b47-4f58-a1b3-cb68f39100a0.png" width=250>
