### PR TITLE
Add a configuration for license URL.

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -126,14 +126,14 @@
     <br />
     {% trans %}Examples, recipes, and other code in the documentation are additionally licensed under the Zero Clause BSD License.{% endtrans %}
     <br />
-    {% trans pathto_license=license_file %}See <a href="{{ license_file }}">History and License</a> for more information.{% endtrans %}
-    <br /><br />
+    {% if theme_license_url %}{% trans license_file=theme_license_url %}See <a href="{{ license_file }}">History and License</a> for more information.{% endtrans %}<br />{% endif %}
+    <br />
 
     {% include "footerdonate.html" %}
     <br />
 
     {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
-    {% if theme_issues_url %}{% trans pathto_bugs=theme_issues_url %}<a href="{{ theme_issues_url }}">Found a bug</a>?{% endtrans %}{% endif %}
+    {% if theme_issues_url %}{% trans %}<a href="{{ theme_issues_url }}">Found a bug</a>?{% endtrans %}{% endif %}
     <br />
 
     {% trans sphinx_version=sphinx_version|e %}Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}

--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -25,6 +25,7 @@ codebgcolor = #eeffcc
 codetextcolor = #333333
 
 issues_url =
+license_url =
 root_name = Python
 root_url = https://www.python.org/
 root_icon = py.svg


### PR DESCRIPTION
closes #89

You're right @merwok, the assignment were reversed (and useless so they were not introducing a bug).

I made the link to the license configurable, so we could add `license_url` cpython side to point to it (near it's `issues_url` in `Doc/config.py`)