### PR TITLE
Fix mobile nav obstructing content

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -266,6 +266,9 @@ dl > dt span ~ em {
     html {
         scroll-padding-top: 40px;
     }
+    body {
+        margin-top: 40px;
+    }
 
     /* Top navigation bar */
     .mobile-nav {
@@ -512,7 +515,6 @@ dl > dt span ~ em {
         width: 100%;
     }
     .document {
-        padding-top: 40px;
         position: relative;
         z-index: 0;
     }


### PR DESCRIPTION
Instead of adding the height of `.mobile-nav` at the top of `.document` it is now added at the top of `body`.

Closes https://github.com/python/python-docs-theme/issues/95