### PR TITLE
A11y: Increase the target area for single-letter index links

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -230,6 +230,10 @@ dl > dt span ~ em {
     padding-left: 20px;
 }
 
+div.genindex-jumpbox a {
+    padding: 0 0.5em;
+}
+
 @media (max-width: 1023px) {
     /* Body layout */
     div.body {

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -230,8 +230,16 @@ dl > dt span ~ em {
     padding-left: 20px;
 }
 
+div.genindex-jumpbox,
+div.genindex-jumpbox > p {
+    display: inline-flex;
+    flex-wrap: wrap;
+}
+
 div.genindex-jumpbox a {
-    padding: 0 0.5em;
+    margin: 0 5px;
+    min-width: 30px;
+    text-align: center;
 }
 
 @media (max-width: 1023px) {


### PR DESCRIPTION
Fixes https://github.com/python/cpython/issues/101109.

[Sphinx auto-generates index pages](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#index-generating-markup
) for entries with `.. index::`. 

At the top of these pages:

* https://docs.python.org/3/genindex.html
* https://docs.python.org/3/genindex-all.html

It generates a list of links to each index initial letter:

<img width="832" alt="image" src="https://user-images.githubusercontent.com/1324225/213150850-c26d604a-1457-437f-bb15-10c2017343ee.png">

However, these links are narrow and have very small clickable target areas, most around 10-15 pixels wide, and "I" is only ~5 pixels wide:

<img width="827" alt="image" src="https://user-images.githubusercontent.com/1324225/213156696-0d782afa-7fb8-4372-93cd-08258e502854.png">

They can be hard to click for those with physical issues that make small, precision movements difficult.

[WebAIM say](https://webaim.org/techniques/hypertext/link_text):

> The danger in using single characters as links—or in using any sort of small link (such as a 10 pixel by 10 pixel graphic)—is that some users will have difficulty clicking on such a small area. Someone with cerebral palsy, for example, may be able to use the hands to manipulate a mouse, but may have difficulty with the precise movements and muscle control necessary to click on a small link. Authors can limit these issues by increasing the size of small links, increasing the font size of single character links, or making the target area larger by including whitespace (such as CSS padding) within small link. Additionally, small adjacent links should have adequate whitespace (such as link CSS margins) between them to minimize users inadvertently clicking the wrong link.

So let's improve accessibility and make:

> the target area larger by including whitespace (such as CSS padding) within small link

Here's a demo with this PR:

* https://hugovk-cpython.readthedocs.io/en/accessibilty-index-target-area/genindex.html
* https://hugovk-cpython.readthedocs.io/en/accessibilty-index-target-area/genindex-all.html

<img width="826" alt="image" src="https://user-images.githubusercontent.com/1324225/213158107-0057ef35-a4c6-4f60-bfec-c4718b27497a.png">

Which gives us a width of around 25-30px for most and ~21px for "I":

<img width="809" alt="image" src="https://user-images.githubusercontent.com/1324225/213158202-323c32af-04f9-4a4d-9044-a55fff84e91e.png">
