### PR TITLE
Previews in pull requests

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Project page: https://readthedocs.org/projects/python-docs-theme-previews/
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+  commands:
+    - git clone --depth=1 https://github.com/python/cpython
+    - make html CPYTHON_PATH=cpython
+    - mv cpython/Doc/build _readthedocs

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ html: venv
 
 .PHONY: venv
 venv:
+	python3 -m pip install build
 	python3 -m build
 	cd $(CPYTHON_PATH)/Doc \
 		&& make venv \
@@ -18,5 +19,5 @@ venv:
 .PHONY: help
 help:
 	@echo "html:		default rule; run the \`venv\` rule, and also rebuild the CPython docs"
-	@echo "venv: 		build the package, and install it into the virtual environment"
+	@echo "venv:		build the package, and install it into the virtual environment"
 	@echo "		at $(CPYTHON_PATH)/Doc/venv"

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,29 @@
-CPYTHON_PATH               = ../cpython
+# You can set these variables from the command line.
+CPYTHON_PATH = ../cpython
+PYTHON       = python3
 PACKAGE_ABS_PATH = $(shell pwd)/$(shell find dist/python-docs-theme-*.tar.gz)
 
+
+.PHONY: help
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  venv       to create a venv with necessary tools at $(CPYTHON_PATH)/Doc/venv"
+	@echo "  html       to make standalone CPython HTML files"
+	@echo "  htmlview   to open the index page built by the html target in your browser"
+
+.PHONY: venv
+venv:
+	$(PYTHON) -m pip install build
+	$(PYTHON) -m build
+	cd $(CPYTHON_PATH)/Doc \
+		&& make venv \
+		&& ./venv/bin/pip install $(PACKAGE_ABS_PATH)
 
 .PHONY: html
 html: venv
 	cd $(CPYTHON_PATH)/Doc && \
 		make html
 
-
-.PHONY: venv
-venv:
-	python3 -m pip install build
-	python3 -m build
-	cd $(CPYTHON_PATH)/Doc \
-		&& make venv \
-		&& ./venv/bin/pip install $(PACKAGE_ABS_PATH)
-
-.PHONY: help
-help:
-	@echo "html:		default rule; run the \`venv\` rule, and also rebuild the CPython docs"
-	@echo "venv:		build the package, and install it into the virtual environment"
-	@echo "		at $(CPYTHON_PATH)/Doc/venv"
+.PHONY: htmlview
+htmlview: html
+	$(PYTHON) -c "import os, webbrowser; webbrowser.open('file://' + os.path.realpath('$(CPYTHON_PATH)/Doc/build/html/index.html'))"


### PR DESCRIPTION
Fixes #70.

#70 suggested Read the Docs and Netlify, but we have a bit of a bus factor problem with Netlify on the CPython docs due to only having a single account that can access the admin, so let's use Read the Docs as well. We're using it successfully in the PEPs repo.

Here's a demo build:

* https://readthedocs.org/projects/hugovk-python-docs-theme/builds/19337266/
* https://hugovk-python-docs-theme.readthedocs.io/en/rtd-preview/

Draft because: 

* [x] This builds upon https://github.com/python/python-docs-theme/pull/93 plus my suggestions. I'll rebase after it's merged.

And we need to set up Read the Docs:

* [x] Someone with admin to this repo (because it needs to set up the webhooks; I don't have admin) should import it at https://readthedocs.org/dashboard/import/
* [x] I suggest we use the `python-docs-theme-previews` slug (consistent with `peps-previews` at https://github.com/python/peps)
* [x] Add some more maintainers at https://readthedocs.org/dashboard/python-docs-theme-previews/users/ to improve bus factor

