### PR TITLE
Reduce footer margin only for desktop

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -200,7 +200,6 @@ table.footnote, table.footnote td {
 
 div.footer {
     line-height: 150%;
-    margin-top: -2em;
     text-align: right;
     width: auto;
     margin-right: 10px;
@@ -520,5 +519,11 @@ dl > dt span ~ em {
     .responsive-table__container {
         width: 100%;
         overflow-x: auto;
+    }
+}
+
+@media (min-width: 1024px) {
+    div.footer {
+        margin-top: -2em;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/python/python-docs-theme/issues/100.

The margin above the footer is currently reduced by 2em.

# Desktop

This makes sense for desktop widths (1024+ pixels). With the reduction:

<details>
<summary>Screenshot</summary>

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/216959795-88b749a9-c658-46be-9878-17b6cbcff53a.png">


</details>

If it was removed for desktop there's a bigger gap between the "Quick search" box and the copyright line:

<details>
<summary>Screenshot</summary>

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/216959911-2e32bb11-8a52-4ab7-81c0-8bfb7d5679a0.png">


</details>

# Mobile

But on mobile (< 1024 pixels), it hides the copyright line:

<details>
<summary>Screenshot</summary>

<img width="612" alt="image" src="https://user-images.githubusercontent.com/1324225/216963896-d11649a5-d956-41a6-bf8c-6f4d7f0c5153.png">


</details>

So let's remove this margin only for desktops:

<details>
<summary>Screenshot</summary>

<img width="612" alt="image" src="https://user-images.githubusercontent.com/1324225/216964032-77d7055b-7a03-4b64-9b1e-e7043953587a.png">

</details>

# Demo build

https://hugovk-python-docs-theme.readthedocs.io/en/fix-footer-demo/
