### PR TITLE
Append a hash ?digest to CSS files for cache-busting

### DIFF
--- a/python_docs_theme/__init__.py
+++ b/python_docs_theme/__init__.py
@@ -1,10 +1,61 @@
+import hashlib
 import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List
+
+import sphinx.application
+from sphinx.builders.html import StandaloneHTMLBuilder
+
+THEME_PATH = Path(__file__).parent.resolve()
+
+
+@lru_cache(maxsize=None)
+def _asset_hash(path: str) -> str:
+    """Append a `?digest=` to an url based on the file content."""
+    full_path = THEME_PATH / path.replace("_static/", "static/")
+    digest = hashlib.sha1(full_path.read_bytes()).hexdigest()
+
+    return f"{path}?digest={digest}"
+
+
+def _add_asset_hashes(static: List[str], add_digest_to: List[str]) -> None:
+    for asset in add_digest_to:
+        index = static.index(asset)
+        static[index].filename = _asset_hash(asset)  # type: ignore
+
+
+def _html_page_context(
+    app: sphinx.application.Sphinx,
+    pagename: str,
+    templatename: str,
+    context: Dict[str, Any],
+    doctree: Any,
+) -> None:
+    if app.config.html_theme != "python_docs_theme":
+        return
+
+    assert isinstance(app.builder, StandaloneHTMLBuilder)
+
+    if "css_files" in context:
+        if "_static/pydoctheme.css" not in context["css_files"]:
+            raise ValueError(
+                "This documentation is not using `pydoctheme.css` as the stylesheet. "
+                "If you have set `html_style` in your conf.py file, remove it."
+            )
+
+        _add_asset_hashes(
+            context["css_files"],
+            ["_static/pydoctheme.css"],
+        )
 
 
 def setup(app):
     current_dir = os.path.abspath(os.path.dirname(__file__))
     app.add_html_theme(
         'python_docs_theme', current_dir)
+
+    app.connect("html-page-context", _html_page_context)
 
     return {
         'parallel_read_safe': True,

--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -1,6 +1,6 @@
 [theme]
 inherit = default
-stylesheet = pydoctheme.css?2022.1
+stylesheet = pydoctheme.css
 pygments_style = default
 
 [options]


### PR DESCRIPTION
Fix https://github.com/python/python-docs-theme/issues/78.

Append a `?digest=hash` to the end of the `pydoctheme.css`, computed from the file contents, so when a new CSS file is deployed, the old one is no longer used from the browser cache.

For example:

`<link rel="stylesheet" type="text/css" href="_static/pydoctheme.css?digest=afc8307635b40ad4bb21df93e5fc348bcdad7f27" />`

This is based on how @pradyunsg's Furo theme does it:

https://github.com/pradyunsg/furo/blob/193643fdb6787501195555244f4a9e953ef544bb/src/furo/__init__.py#L149-L161

# Demo

View the source of pages at https://python-docs-theme-previews--108.org.readthedocs.build/en/108/