### PR TITLE
Skip cache-busting for old Sphinx

### DIFF
--- a/python_docs_theme/__init__.py
+++ b/python_docs_theme/__init__.py
@@ -37,7 +37,7 @@ def _html_page_context(
 
     assert isinstance(app.builder, StandaloneHTMLBuilder)
 
-    if "css_files" in context:
+    if sphinx.version_info >= (4,) and "css_files" in context:
         if "_static/pydoctheme.css" not in context["css_files"]:
             raise ValueError(
                 "This documentation is not using `pydoctheme.css` as the stylesheet. "


### PR DESCRIPTION
Fix for https://github.com/python/python-docs-theme/pull/108#issuecomment-1464879086.

Skip cache busting for Sphinx 3 and older.