### PR TITLE
Override font for .sig for consistency with other code blocks

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -255,7 +255,8 @@ div.footer a:hover {
     color: #229;
 }
 
-dl > dt span ~ em {
+dl > dt span ~ em,
+.sig {
     font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Liberation Mono", Menlo, Monaco, Consolas, monospace;
 }
 


### PR DESCRIPTION
The `basic.css` Sphinx stylesheet introduces a `.sig` rule, which sets some monospace fonts for the signature. The `pydoctheme.css` stylesheet has its own list of fonts, applied to some other elements, but not `.sig`. The result is an inconsistency on Windows systems with both Cascadia Mono and Consolas installed (I believe that happens in a default Windows 11 install). Compare the glyphs for `64` in the function signature and in the code block below it:

![image](https://user-images.githubusercontent.com/327323/227724234-da234224-f97e-4c20-bbb0-452161a4aeab.png)