### PR TITLE
Include license file in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ urls.Code = "https://github.com/python/python-docs-theme"
 urls.Download = "https://pypi.org/project/python-docs-theme/"
 urls.Homepage = "https://github.com/python/python-docs-theme/"
 urls."Issue tracker" = "https://github.com/python/python-docs-theme/issues"
-license.text = "PSF-2.0"
+license.file = "LICENSE"
 requires-python = ">=3.8"
 
 # Classifiers list: https://pypi.org/classifiers/


### PR DESCRIPTION
Fixes https://github.com/python/python-docs-theme/issues/122.

With flit-core, looks like we need to explicitly include the licence file:

> **license**
> 
> A table with either a `file` key (a relative path to a license file) or a `text` key (the license text).

https://flit.pypa.io/en/stable/pyproject_toml.html

With setuptools, the 2022.1 sdist includes:

```
-rw-r--r--   1 hugo  staff   2.4K Mar 22 15:34 LICENSE
-rw-r--r--   1 hugo  staff    67B Mar 27 17:44 MANIFEST.in
-rw-r--r--   1 hugo  staff   1.4K Mar 27 17:44 PKG-INFO
-rw-r--r--   1 hugo  staff   858B Mar 22 15:34 README.rst
-rw-r--r--   1 hugo  staff   105B Mar 27 17:44 pyproject.toml
drwxr-xr-x   7 hugo  staff   224B Mar 27 17:44 python_docs_theme
drwxr-xr-x   7 hugo  staff   224B Mar 27 17:44 python_docs_theme.egg-info
-rw-r--r--   1 hugo  staff    67B Mar 27 17:44 setup.cfg
-rw-r--r--   1 hugo  staff   1.2K Mar 27 17:44 setup.py
```

With flit, the v2023.3.1 sdist includes:

```
-rw-r--r--  1 hugo  staff   2.0K Jan  1  1970 PKG-INFO
-rw-r--r--  1 hugo  staff   858B Mar 22 15:34 README.rst
-rw-r--r--  1 hugo  staff   1.4K Mar 27 17:44 pyproject.toml
drwxr-xr-x  7 hugo  staff   224B Mar 27 17:47 python_docs_theme
```

With this PR, the sdist includes:

```
-rw-r--r--  1 hugo  staff   2.4K Mar 22 15:34 LICENSE
-rw-r--r--  1 hugo  staff   2.0K Jan  1  1970 PKG-INFO
-rw-r--r--  1 hugo  staff   858B Mar 22 15:34 README.rst
-rw-r--r--  1 hugo  staff   1.4K Mar 27 17:47 pyproject.toml
drwxr-xr-x  7 hugo  staff   224B Mar 27 17:48 python_docs_theme
```
