### PR TITLE
Remove searchbox ID from form

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -103,7 +103,7 @@
             </a>
             <span class="version_switcher_placeholder"></span>
             {%- if pagename != "search" and builder != "singlehtml" %}
-            <form id="searchbox" role="search" class="search" action="{{ pathto('search') }}" method="get">
+            <form role="search" class="search" action="{{ pathto('search') }}" method="get">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" class="search-icon">
                     <path fill-rule="nonzero" fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 001.48-5.34c-.47-2.78-2.79-5-5.59-5.34a6.505 6.505 0 00-7.27 7.27c.34 2.8 2.56 5.12 5.34 5.59a6.5 6.5 0 005.34-1.48l.27.28v.79l4.25 4.25c.41.41 1.08.41 1.49 0 .41-.41.41-1.08 0-1.49L15.5 14zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
                 </svg>


### PR DESCRIPTION
Fixes #117.

The "Hide Search Matches" was not properly integrated into the layout, removing the ID reverts it to the previous behaviour where the toggle was suppressed.

Ideally we would have this working properly, however, sphinx sets this based on ID and we have more than one search forms so this would not show up properly (at the top and bottom of the desktop layout, and one in the mobile layout). With some CSS trickery it might be possible to reuse a single form element for the desktop and mobile layout such that this could be reasonably supported (and do without the toggle for the search form at the bottom) though this is a decent bit more complex and I am currently short on time.