### PR TITLE
Dark mode: add class to invert image brightness

### DIFF
--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -120,3 +120,7 @@ div.note {
 .nav-content {
     background-color: black;
 }
+
+img.invert-in-dark-mode {
+    filter: invert(1) hue-rotate(.5turn);
+}


### PR DESCRIPTION
For https://github.com/python/cpython/issues/103960.

Re: https://github.com/python/python-docs-theme/pull/44#issuecomment-1526951114.

Add a class to invert image brightness (but not contrast), similar to how we handled it for the PEPs repo: https://github.com/python/peps/pull/2409 and https://github.com/python/peps/pull/2949.

We can then add this class to images like this:

```rst
.. figure:: hashlib-blake2-tree.png
   :alt: Explanation of tree mode parameters.
   :class: invert-in-dark-mode
```

Which changes this:

<details>
<summary>Details</summary>

<img width="769" alt="image" src="https://user-images.githubusercontent.com/1324225/235230096-1af8badd-2755-44ae-a0bd-e8f1250cf992.png">


</details>

Into:

<details>
<summary>Details</summary>

<img width="778" alt="image" src="https://user-images.githubusercontent.com/1324225/235229933-e02a667d-90c7-4ef9-a90c-925dd448a8ee.png">


</details>

And light mode remains unchanged:

<details>
<summary>Details</summary>

<img width="770" alt="image" src="https://user-images.githubusercontent.com/1324225/235230018-039d3ca1-e33f-469b-8360-c0f0a0439076.png">

</details>

This can be merged before or after https://github.com/python/cpython/pull/103983.