### PR TITLE
Dark mode: fix contrast for C++ specific styling

### DIFF
--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -124,3 +124,12 @@ div.note {
 img.invert-in-dark-mode {
     filter: invert(1) hue-rotate(.5turn);
 }
+
+/* -- object description styles --------------------------------------------- */
+
+/* C++ specific styling */
+
+.sig.c   .k, .sig.c   .kt,
+.sig.cpp .k, .sig.cpp .kt {
+    color: #5283ff;
+}

--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -129,6 +129,7 @@ img.invert-in-dark-mode {
 
 /* C++ specific styling */
 
+/* Override Sphinx's basic.css to fix colour contrast */
 .sig.c   .k, .sig.c   .kt,
 .sig.cpp .k, .sig.cpp .kt {
     color: #5283ff;


### PR DESCRIPTION
# Before

1. Visit https://docs.python.org/3.12/c-api/arg.html#numbers
2. Look at the C keywords such as `unsigned char`

<table>
<tr>
 <td><img src=https://github.com/python/python-docs-theme/assets/1324225/cdcefd44-366e-455c-9990-032b8483229f>
 <td><img src=https://github.com/python/python-docs-theme/assets/1324225/6d502b0b-cee2-44a5-8e4e-6dde1009e17c>
</table>

3. Dark mode: the dark blue text on dark background is very hard to read
4. Check the contrast ratio in devtools, it's below the WCAG AA guidelines of 4.5:

![image](https://github.com/python/python-docs-theme/assets/1324225/16bf7454-9cf2-45b3-8649-a9abadd0ca94)

5. (Light mode is fine, ratio is 9.88, above the AAA ratio of 7.0.)

# After

That is defined by Sphinx: https://github.com/sphinx-doc/sphinx/blob/d3c91f951255c6729a53e38c895ddc0af036b5b9/sphinx/themes/basic/static/basic.css_t#L547-L550

Copy that CSS to our dark mode file and use `#5283ff` as suggested by devtools, and the dark mode is improved, with no change to light mode:

<table>
<tr>
 <td>
<img src=https://github.com/python/python-docs-theme/assets/1324225/df16a2a7-eccb-4940-903a-2ecadb0be608>
 <td>
<img src=https://github.com/python/python-docs-theme/assets/1324225/37a78f0e-5e5d-4c97-a900-14cc5d29c178>
</table>

# Preview

https://python-docs-theme-previews--133.org.readthedocs.build/en/133/c-api/arg.html#numbers
