### PR TITLE
Enable search shortcuts

### DIFF
--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -33,3 +33,4 @@ root_url = https://www.python.org/
 root_icon = py.svg
 root_include_title = True
 copyright_url =
+enable_search_shortcuts = True


### PR DESCRIPTION
Enable already-existing JavaScript flag.

Included since Sphinx 4.5.0 https://www.sphinx-doc.org/en/master/changes.html#release-4-5-0-released-mar-28-2022

The [doctools.js file that is served today](https://docs.python.org/3/_static/doctools.js) includes the functionality - look for `DOCUMENTATION_OPTIONS.ENABLE_SEARCH_SHORTCUTS`

I _think_ that the only piece needed is setting the config option [`enable_search_shortcuts = True`](https://github.com/sphinx-doc/sphinx/blob/5cf3dce36ec35c429724bf1312ece9faa0c8db39/sphinx/themes/basic/theme.conf#L13C1-L14C1) in https://github.com/python/python-docs-theme/blob/4dbc102a556c520b10fc387821967e54dee77654/python_docs_theme/theme.conf

We inherit from [`default` theme](https://github.com/sphinx-doc/sphinx/blob/5cf3dce36ec35c429724bf1312ece9faa0c8db39/sphinx/themes/default/theme.conf#L2), which [inherits `classic`](https://github.com/sphinx-doc/sphinx/blob/5cf3dce36ec35c429724bf1312ece9faa0c8db39/sphinx/themes/classic/theme.conf#L2), which inherits [`basic` theme](https://github.com/sphinx-doc/sphinx/blob/5cf3dce36ec35c429724bf1312ece9faa0c8db39/sphinx/themes/basic/theme.conf#L1-L2).

Alternative to #131 