### PR TITLE
Sphinx 6.2 fix: add nav.contents where that div.topic is used

### DIFF
--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -104,7 +104,8 @@ div.warning {
 }
 
 div.topic,
-div.note {
+div.note,
+nav.contents {
     background-color: rgba(255, 255, 255, 0.1);
     border-color: currentColor;
 }


### PR DESCRIPTION
Fixes https://github.com/python/python-docs-theme/issues/132 by applying the same fix as https://github.com/sphinx-doc/sphinx/commit/5806f0af2788db40661d62e5e88c2c1560ae46b6.

See https://github.com/python/python-docs-theme/issues/132#issuecomment-1625268649 for details.

Compare:

* Before: https://docs.python.org/3.13/library/asyncio-task.html
* After: https://python-docs-theme-previews--138.org.readthedocs.build/en/138/library/asyncio-task.html

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td>
<img src=https://github.com/python/python-docs-theme/assets/1324225/855ce7ad-dc97-4863-bc6f-4d8f1d248d76>
 <td>
<img src=https://github.com/python/python-docs-theme/assets/1324225/10c38795-38c9-4506-970e-256b6af19f7a>
</table>
