### PR TITLE
Don't let long code literals extend beyond the right side of the screen

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -368,6 +368,11 @@ div.genindex-jumpbox a {
     body {
         margin-top: 40px;
     }
+    /* Don't let long code literals extend beyond the right side of the screen */
+    span.pre {
+        overflow-wrap: break-word;
+        white-space: unset;
+    }
 
     /* Top navigation bar */
     .mobile-nav {

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -84,6 +84,13 @@ form.inline-search input[type='submit'] {
 
 div.document {
     display: flex;
+    /* Don't let long code literals extend beyond the right side of the screen */
+    overflow-wrap: break-word;
+}
+
+/* Don't let long code literals extend beyond the right side of the screen */
+span.pre {
+    white-space: unset;
 }
 
 div.sphinxsidebar {
@@ -367,11 +374,6 @@ div.genindex-jumpbox a {
     }
     body {
         margin-top: 40px;
-    }
-    /* Don't let long code literals extend beyond the right side of the screen */
-    span.pre {
-        overflow-wrap: break-word;
-        white-space: unset;
     }
 
     /* Top navigation bar */


### PR DESCRIPTION
Fixes https://github.com/python/python-docs-theme/issues/129.

With mobile, compare:

* https://docs.python.org/3.13/whatsnew/3.12.html
* https://python-docs-theme-previews--139.org.readthedocs.build/en/139/whatsnew/3.12.html

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td width=50% valign=top>
<img src=https://github.com/python/python-docs-theme/assets/1324225/6ec979dd-455c-45f4-8f50-fa54dcb775b4>
<img src=https://github.com/python/python-docs-theme/assets/1324225/007fdd59-4677-4441-b450-ab0fe405b54c>
 <td width=50% valign=top>
<img src=https://github.com/python/python-docs-theme/assets/1324225/e37ff537-bb19-4178-8e09-d430b3d7b281>
<tr>
 <td>
<img src=https://github.com/python/python-docs-theme/assets/1324225/999100be-4d14-44eb-86fa-430e92380e76>
 <td>
<img src=https://github.com/python/python-docs-theme/assets/1324225/03ba995c-8da9-41a0-8a57-52dbc4222d59>
</table>
