### PR TITLE
Use correct block, enable built-in slash keypress

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -82,7 +82,7 @@
     {{ super() }}
 {%- endblock -%}
 
-{%- block body_tag %}
+{%- block document %}
 {{ super() }}
 {%- if builder != 'htmlhelp' %}
 <div class="mobile-nav">

--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -82,11 +82,6 @@
     {{ super() }}
 {%- endblock -%}
 
-{%- block css -%}
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {{ super() }}
-{%- endblock -%}
-
 {%- block body_tag %}
 {{ super() }}
 {%- if builder != 'htmlhelp' %}


### PR DESCRIPTION
Includes a commit removing a duplicate block.

When the template was made responsive, the choice was made to override
the `body_tag` fragment.
The `body_tag` block is a literal `<body>` which allows the theme developer
to set properties on the `body` tag.
See: https://github.com/sphinx-doc/sphinx/pull/4140

Instead, use the `document` block as documented.
https://www.sphinx-doc.org/en/master/development/templating.html#blocks

Overriding the correct block places the `mobile-nav` section _after_ the
majority of the other HTML parts, which enables the correct function of
the `/` keyboard shortcut.

Resolves https://github.com/python/python-docs-theme/issues/130
Closes https://github.com/python/python-docs-theme/pull/131
Closes https://github.com/python/python-docs-theme/pull/135