### PR TITLE
Revert "Use correct block, enable built-in slash keypress"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 # project metadata
 [project]
 name = "python-docs-theme"
-version = "2023.7"
+version = "2023.8"
 description = "The Sphinx theme for the CPython docs and related projects"
 readme = "README.rst"
 urls.Code = "https://github.com/python/python-docs-theme"

--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -82,7 +82,12 @@
     {{ super() }}
 {%- endblock -%}
 
-{%- block document %}
+{%- block css -%}
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {{ super() }}
+{%- endblock -%}
+
+{%- block body_tag %}
 {{ super() }}
 {%- if builder != 'htmlhelp' %}
 <div class="mobile-nav">


### PR DESCRIPTION
Reverts python/python-docs-theme#141 due to https://github.com/python/python-docs-theme/issues/144.