### PR TITLE
Build & release to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -2,10 +2,9 @@ name: Build & maybe upload PyPI package
 
 on:
   push:
-    branches: [main]
+    branches:
     tags: ["*"]
   pull_request:
-    branches: [main]
   release:
     types:
       - published
@@ -24,28 +23,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: hynek/build-and-inspect-python-package@v1
-
-  # Upload to Test PyPI on every commit on main.
-  release-test-pypi:
-    name: Publish in-dev package to test.pypi.org
-    if: github.repository_owner == 'python' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    needs: build-package
-
-    permissions:
-      id-token: write
-
-    steps:
-      - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v3
-        with:
-          name: Packages
-          path: dist
-
-      - name: Upload package to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
 
   # Upload to real PyPI on GitHub Releases.
   release-pypi:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -26,6 +26,7 @@ jobs:
   release-pypi:
     name: Publish to PyPI
     environment: release-pypi
+    # Only run for published releases.
     if: github.repository_owner == 'python' && github.event.action == 'published'
     runs-on: ubuntu-latest
     needs: build-package

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   # Always build & lint package.
@@ -35,6 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-package
 
+    permissions:
+      id-token: write
+
     steps:
       - name: Download packages built by build-and-inspect-python-package
         uses: actions/download-artifact@v3
@@ -54,6 +56,9 @@ jobs:
     if: github.repository_owner == 'python' && github.event.action == 'published'
     runs-on: ubuntu-latest
     needs: build-package
+
+    permissions:
+      id-token: write
 
     steps:
       - name: Download packages built by build-and-inspect-python-package

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -2,8 +2,6 @@ name: Build & maybe upload PyPI package
 
 on:
   push:
-    branches:
-    tags: ["*"]
   pull_request:
   release:
     types:

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -1,4 +1,3 @@
----
 name: Build & maybe upload PyPI package
 
 on:
@@ -50,7 +49,7 @@ jobs:
 
   # Upload to real PyPI on GitHub Releases.
   release-pypi:
-    name: Publish released package to pypi.org
+    name: Publish to PyPI
     environment: release-pypi
     if: github.repository_owner == 'python' && github.event.action == 'published'
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -1,0 +1,67 @@
+---
+name: Build & maybe upload PyPI package
+
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+  pull_request:
+    branches: [main]
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: hynek/build-and-inspect-python-package@v1
+
+  # Upload to Test PyPI on every commit on main.
+  release-test-pypi:
+    name: Publish in-dev package to test.pypi.org
+    if: github.repository_owner == 'python' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v3
+        with:
+          name: Packages
+          path: dist
+
+      - name: Upload package to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  # Upload to real PyPI on GitHub Releases.
+  release-pypi:
+    name: Publish released package to pypi.org
+    environment: release-pypi
+    if: github.repository_owner == 'python' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v3
+        with:
+          name: Packages
+          path: dist
+
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -22,8 +22,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - uses: hynek/build-and-inspect-python-package@v1
 


### PR DESCRIPTION
We discussed in the last monthly docs meeting to automate PyPI deploys using the new "Trusted Publishing", and the consensus was it's a good idea:

* https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

This would make releasing easier, and also open the release process to other core devs with the commit bit.

Here's a PR to set up the workflow, we'll also need to set up trusted publishing on TestPyPI and PyPI.

---

This workflow does three things:

<img width="600" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/699042e6-ae85-4f8d-b868-042d781f766b">

It is based on @hynek's neat https://github.com/python-attrs/attrs/blob/main/.github/workflows/pypi-package.yml, which I'm successfully using in my own projects.

# 1.

For all runs, it builds and lints the PyPI sdist and wheel. This makes sure the non-publishing steps are working smoothly, ahead of uploading. It uses @hynek's excellent https://github.com/hynek/build-and-inspect-python-package action, which creates a nice summary, for example:

<img width="1101" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/5066c184-9af4-4da3-8944-c1dc046b0978">

We can see it creates three handy zips if we want to check what would be uploaded to PyPI, and three handy toggles that show the contents. Try it here:

https://github.com/python/python-docs-theme/actions/runs/5919197594?pr=148

# 2.

For commits to `main` we publish to TestPyPI. This helps us know the publishing process is nicely oiled to avoid surprises on release day. It uses the packages that were already created in step 1.

# 3. 

For published GitHub releases we publish to the real PyPI. Also uses packages created in step 1.

---

# TODO

* ~[n/a] Set up trusted publishing on TestPyPI:~
    1. ~Go to https://test.pypi.org/manage/project/python-docs-theme/settings/publishing/~
    2. ~Add a new publisher like:~

<details>
<summary>screenshot</summary>

<img width="456" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/86459d80-a0b7-4d8e-bac7-6ed703046140">

</details>

* [x] Set up trusted publishing on PyPI:
    1. Go to https://pypi.org/manage/project/python-docs-theme/settings/publishing/
    2. Add a new publisher as above


~@willingc I see you're the only maintainer for https://test.pypi.org/project/python-docs-theme/, please could you set up the above for TestPyPI? It's probably a good opportunity to add some extra owners/maintainers such as @Mariatta, to improve the bus factor.~

@willingc You're also one of the maintainers for https://pypi.org/project/python-docs-theme/, so perhaps you could do PyPI too? 
