### PR TITLE
Dark mode: Also give aside.topic a dark background

### DIFF
--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -103,6 +103,7 @@ div.warning {
     background-color: rgba(255, 0, 0, 0.5);
 }
 
+aside.topic,
 div.topic,
 div.note,
 nav.contents {


### PR DESCRIPTION
Fixes https://github.com/python/python-docs-theme/issues/149.

PR https://github.com/python/python-docs-theme/pull/138 added `nav.contents` to places where `div.note` and `div.topic` were given a dark background.

This new one:

<img width="828" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/7766f723-06f5-40bd-88f4-485b260be80c">

isn't any of those. Instead it's an `aside.topic`:

<img width="1102" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/26010117-62e4-401f-9f40-280190364328">

Let's give it a dark background too:

<img width="843" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/41b9117c-a810-46a5-aeca-ba845f6eb522">
