### PR TITLE
Prepare 2023.8 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Changelog
 - Sphinx 6.2 fix: add ``nav.contents`` where ``div.topic`` is used (#138)
    Contributed by Hugo van Kemenade
 - Dark mode: fix contrast for C++ specific styling (#133)
-  Contributed by Hugo van Kemenade
+   Contributed by Hugo van Kemenade
 - Don't let long code literals extend beyond the right side of the screen (#139)
    Contributed by Hugo van Kemenade
 - Test with Python 3.12 (#140)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog
 =========
 
+`2023.8 <https://github.com/python/python-docs-theme/releases/tag/v2023.8>`_
+----------------------------------------------------------------------------
+
+- Add Python 3.12 and 3.13 classifiers (#147)
+    Contributed by Hugo van Kemenade
+- Dark mode: Also give aside.topic a dark background (#150)
+   Contributed by Hugo van Kemenade
+- Revert "Enable the slash keypress to focus the search field (#141)" (#146)
+   Contributed by Hugo van Kemenade
+
 `2023.7 <https://github.com/python/python-docs-theme/releases/tag/v2023.7>`_
 ----------------------------------------------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 ----------------------------------------------------------------------------
 
 - Add Python 3.12 and 3.13 classifiers (#147)
-    Contributed by Hugo van Kemenade
+   Contributed by Hugo van Kemenade
 - Dark mode: Also give aside.topic a dark background (#150)
    Contributed by Hugo van Kemenade
 - Revert "Enable the slash keypress to focus the search field (#141)" (#146)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Changelog
    Contributed by Hugo van Kemenade
 - Dark mode: Also give aside.topic a dark background (#150)
    Contributed by Hugo van Kemenade
-- Revert "Enable the slash keypress to focus the search field (#141)" (#146)
+- Restore the menu on mobile devices (inadvertently broken in 2023.7) (#146)
    Contributed by Hugo van Kemenade
 
 `2023.7 <https://github.com/python/python-docs-theme/releases/tag/v2023.7>`_


### PR DESCRIPTION
Update changelog.

The `pyproject.toml` version has already been bumped (re: https://github.com/python/python-docs-theme/pull/146#issuecomment-1676714592).