### PR TITLE
Focus search box when pressing slash

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -48,7 +48,7 @@
     {%- if builder != "htmlhelp" %}
     <div class="inline-search" role="search">
         <form class="inline-search" action="{{ pathto('search') }}" method="get">
-          <input placeholder="{{ _('Quick search') }}" aria-label="{{ _('Quick search') }}" type="search" name="q" />
+          <input placeholder="{{ _('Quick search') }}" aria-label="{{ _('Quick search') }}" type="search" name="q" id="search-box" />
           <input type="submit" value="{{ _('Go') }}" />
         </form>
     </div>
@@ -76,6 +76,7 @@
         {%- if not embedded %}
             <script type="text/javascript" src="{{ pathto('_static/copybutton.js', 1) }}"></script>
             <script type="text/javascript" src="{{ pathto('_static/menu.js', 1) }}"></script>
+            <script type="text/javascript" src="{{ pathto('_static/search-focus.js', 1) }}"></script>
             <script type="text/javascript" src="{{ pathto('_static/themetoggle.js', 1) }}"></script>
         {%- endif -%}
     {%- endif -%}

--- a/python_docs_theme/static/search-focus.js
+++ b/python_docs_theme/static/search-focus.js
@@ -1,10 +1,21 @@
+function isInputFocused() {
+  const activeElement = document.activeElement;
+  return (
+    activeElement.tagName === 'INPUT' ||
+    activeElement.tagName === 'TEXTAREA' ||
+    activeElement.isContentEditable
+  );
+}
+
 document.addEventListener('keydown', function(event) {
   if (event.key === '/') {
-     // Prevent "/" from being entered in the search box
-    event.preventDefault();
+    if (!isInputFocused()) {
+      // Prevent "/" from being entered in the search box
+      event.preventDefault();
 
-    // Set the focus on the search box
-    let searchBox = document.getElementById('search-box');
-    searchBox.focus();
+      // Set the focus on the search box
+      const searchBox = document.getElementById('search-box');
+      searchBox.focus();
+    }
   }
 });

--- a/python_docs_theme/static/search-focus.js
+++ b/python_docs_theme/static/search-focus.js
@@ -1,0 +1,10 @@
+document.addEventListener('keydown', function(event) {
+  if (event.key === '/') {
+     // Prevent "/" from being entered in the search box
+    event.preventDefault();
+
+    // Set the focus on the search box
+    let searchBox = document.getElementById('search-box');
+    searchBox.focus();
+  }
+});


### PR DESCRIPTION
Fixes https://github.com/python/python-docs-theme/issues/130.

Same as https://github.com/python/python-docs-theme/pull/131, had to create a new PR.

Re-opening as https://github.com/python/python-docs-theme/pull/135 didn't work out.

# Demo

https://python-docs-theme-previews--153.org.readthedocs.build/en/153/