### PR TITLE
Underline links for readability and a11y

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -30,7 +30,8 @@ pre {
 }
 
 a {
-    text-decoration: underline;
+    text-decoration: underline 1px;
+    text-underline-offset: 0.3em;
 }
 
 body {
@@ -181,7 +182,7 @@ div.body {
 
 div.body p, div.body dd, div.body li, div.body blockquote {
     text-align: left;
-    line-height: 1.4;
+    line-height: 1.6;
 }
 div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6 {
     margin: 0;

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -29,6 +29,10 @@ pre {
     color: inherit;
 }
 
+a {
+    text-decoration: underline;
+}
+
 body {
     margin-left: 1em;
     margin-right: 1em;

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -29,7 +29,7 @@ pre {
     color: inherit;
 }
 
-a {
+a[href] {
     text-decoration: underline 1px;
     text-underline-offset: 0.3em;
 }


### PR DESCRIPTION
Currently this theme changes the colour of hyperlinks but doesn't underline them.

For example: https://docs.python.org/3/whatsnew/3.12.html

<img width="819" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/430e746d-329c-4960-a090-91278306ca50">

When hovering over a link, it changes colour and a link is shown (see "f-strings" here):

<img width="820" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/57fe1cf5-25ac-4233-95ba-6b8761317144">

---

However, links should always be underlined. This improves accessibility and also readability.

For example:

* https://accessibility.oit.ncsu.edu/it-accessibility-at-nc-state/developers/accessibility-handbook/mouse-and-keyboard-events/links/do-not-remove-the-underline-from-links/
* https://adrianroselli.com/2019/01/underlines-are-beautiful.html

Not using underlines also fails a WCAG check:

* https://www.w3.org/TR/WCAG20-TECHS/F73.html

And GitHub have just enabled underlines:

* https://github.blog/changelog/2023-10-18-new-default-underlined-links-for-improved-accessibility/

# Demo

https://python-docs-theme-previews--160.org.readthedocs.build/en/160/whatsnew/3.12.html

<img width="826" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/81ef43bd-aaf6-48a2-8ab2-2f2289c6f571">

<img width="817" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/303065dd-cf99-48e9-b0be-b321a37027fc">


