### PR TITLE
Dark mode: fix contrast of footer highlight

### DIFF
--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -60,6 +60,10 @@ span.highlighted {
     background-color: #616161;
 }
 
+.footnote:target {
+    background-color: #2c3e50;
+}
+
 /* Below for most things in text */
 
 dl.field-list > dt {


### PR DESCRIPTION
Fixes https://github.com/python/python-docs-theme/issues/161.

# Before

<img width="823" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/27ea81d9-0b58-4a93-8685-e484e17e6fe8">

# After

<img width="829" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/6d5e5e6e-638b-4d3f-8568-33e67303155c">


# No change to light mode

<img width="825" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/4b2f1e52-4fb0-4f38-b883-4dc34e784f7f">

# Preview

https://python-docs-theme-previews--162.org.readthedocs.build/en/162/library/gettext.html
