### PR TITLE
Consistently reference `theme_root_icon`

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -14,7 +14,7 @@
           </li>
           {%- endfor %}
           {%- block rootrellink %}
-          <li><img src="{{ pathto('_static/py.svg', 1) }}" alt="python logo" style="vertical-align: middle; margin-top: -1px"/></li>
+          <li><img src="{{ pathto('_static/' + theme_root_icon, 1) }}" alt="python logo" style="vertical-align: middle; margin-top: -1px"/></li>
           <li><a href="{{theme_root_url}}">{{theme_root_name}}</a>{{ reldelim1 }}</li>
           <li class="switchers">
             <div class="language_switcher_placeholder"></div>
@@ -100,7 +100,7 @@
         </label>
         <span class="nav-items-wrapper">
             <a href="{{ theme_root_url }}" class="nav-logo">
-                <img src="{{ pathto('_static/py.svg', 1) }}" alt="Logo"/>
+                <img src="{{ pathto('_static/' + theme_root_icon, 1) }}" alt="Logo"/>
             </a>
             <span class="version_switcher_placeholder"></span>
             {%- if pagename != "search" and builder != "singlehtml" %}

--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -14,7 +14,7 @@
           </li>
           {%- endfor %}
           {%- block rootrellink %}
-          <li><img src="{{ pathto('_static/' + theme_root_icon, 1) }}" alt="{{theme_root_icon_alt_text}}" style="vertical-align: middle; margin-top: -1px"/></li>
+          <li><img src="{{ pathto('_static/' ~ theme_root_icon, 1) }}" alt="{{ theme_root_icon_alt_text }}" style="vertical-align: middle; margin-top: -1px"/></li>
           <li><a href="{{theme_root_url}}">{{theme_root_name}}</a>{{ reldelim1 }}</li>
           <li class="switchers">
             <div class="language_switcher_placeholder"></div>
@@ -100,7 +100,7 @@
         </label>
         <span class="nav-items-wrapper">
             <a href="{{ theme_root_url }}" class="nav-logo">
-                <img src="{{ pathto('_static/' + theme_root_icon, 1) }}" alt="{{theme_root_icon_alt_text}}"/>
+                <img src="{{ pathto('_static/' ~ theme_root_icon, 1) }}" alt="{{ theme_root_icon_alt_text }}"/>
             </a>
             <span class="version_switcher_placeholder"></span>
             {%- if pagename != "search" and builder != "singlehtml" %}

--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -71,7 +71,7 @@
 
 {%- block extrahead -%}
     <link rel="stylesheet" href="{{ pathto('_static/pydoctheme_dark.css', 1) }}" media="(prefers-color-scheme: dark)" id="pydoctheme_dark_css">
-    <link rel="shortcut icon" type="image/png" href="{{ pathto('_static/' + theme_root_icon, 1) }}" />
+    <link rel="shortcut icon" type="image/png" href="{{ pathto('_static/' ~ theme_root_icon, 1) }}" />
     {%- if builder != "htmlhelp" %}
         {%- if not embedded %}
             <script type="text/javascript" src="{{ pathto('_static/copybutton.js', 1) }}"></script>
@@ -121,7 +121,7 @@
             {%- if logo %}
             <p class="logo">
                 <a href="{{ pathto('index') }}">
-                <img class="logo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="Logo"/>
+                <img class="logo" src="{{ pathto('_static/' ~ logo, 1)|e }}" alt="Logo"/>
                 </a>
             </p>
             {%- endif %}

--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -14,7 +14,7 @@
           </li>
           {%- endfor %}
           {%- block rootrellink %}
-          <li><img src="{{ pathto('_static/' + theme_root_icon, 1) }}" alt="python logo" style="vertical-align: middle; margin-top: -1px"/></li>
+          <li><img src="{{ pathto('_static/' + theme_root_icon, 1) }}" alt="{{theme_root_icon_alt_text}}" style="vertical-align: middle; margin-top: -1px"/></li>
           <li><a href="{{theme_root_url}}">{{theme_root_name}}</a>{{ reldelim1 }}</li>
           <li class="switchers">
             <div class="language_switcher_placeholder"></div>
@@ -100,7 +100,7 @@
         </label>
         <span class="nav-items-wrapper">
             <a href="{{ theme_root_url }}" class="nav-logo">
-                <img src="{{ pathto('_static/' + theme_root_icon, 1) }}" alt="Logo"/>
+                <img src="{{ pathto('_static/' + theme_root_icon, 1) }}" alt="{{theme_root_icon_alt_text}}"/>
             </a>
             <span class="version_switcher_placeholder"></span>
             {%- if pagename != "search" and builder != "singlehtml" %}

--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -32,5 +32,5 @@ root_name = Python
 root_url = https://www.python.org/
 root_icon = py.svg
 root_include_title = True
-root_icon_alt_text = Python Logo
+root_icon_alt_text = Python logo
 copyright_url =

--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -32,4 +32,5 @@ root_name = Python
 root_url = https://www.python.org/
 root_icon = py.svg
 root_include_title = True
+root_icon_alt_text = Python Logo
 copyright_url =

--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -31,6 +31,6 @@ license_url =
 root_name = Python
 root_url = https://www.python.org/
 root_icon = py.svg
-root_include_title = True
 root_icon_alt_text = Python logo
+root_include_title = True
 copyright_url =


### PR DESCRIPTION
Removed explicit `py.svg` references in `layout.html` with `theme_root_icon` paths. 

This pull request changes paths lines 17 and 103 to match line 74 in the base branch.