### PR TITLE
Show logs on error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,10 @@ jobs:
           --theme $(pwd)
           --language en
           --branch ${{ matrix.branch }}
+      - name: Show logs
+        if: failure()
+        run: |
+          cat ./logs/docsbuild.log
       - name: Upload
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Currently the 3.8 and 3.9 branches are failing to build, but no error logs are printed on the CI due to `sys.stderr.isatty()` being false:

https://github.com/python/docsbuild-scripts/blob/f0a570aec824c7d775ea9d345a89d1b10d0f11b2/build_docs.py#L604-L617

This will show the logs if there's a failure.