### PR TITLE
Add `hosted_on` variable for a link in the footer

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -143,6 +143,9 @@
     {% trans %}Examples, recipes, and other code in the documentation are additionally licensed under the Zero Clause BSD License.{% endtrans %}
     <br />
     {% if theme_license_url %}{% trans license_file=theme_license_url %}See <a href="{{ license_file }}">History and License</a> for more information.{% endtrans %}<br />{% endif %}
+    {% if theme_hosted_on %}
+        {% trans hosted_on=theme_hosted_on %}Hosted on {{ hosted_on }}.{% endtrans %}<br />
+    {% endif %}
     <br />
 
     {% include "footerdonate.html" %}

--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -143,9 +143,7 @@
     {% trans %}Examples, recipes, and other code in the documentation are additionally licensed under the Zero Clause BSD License.{% endtrans %}
     <br />
     {% if theme_license_url %}{% trans license_file=theme_license_url %}See <a href="{{ license_file }}">History and License</a> for more information.{% endtrans %}<br />{% endif %}
-    {% if theme_hosted_on %}
-        {% trans hosted_on=theme_hosted_on %}Hosted on {{ hosted_on }}.{% endtrans %}<br />
-    {% endif %}
+    {% if theme_hosted_on %}{% trans hosted_on=theme_hosted_on %}Hosted on {{ hosted_on }}.{% endtrans %}<br />{% endif %}
     <br />
 
     {% include "footerdonate.html" %}

--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -26,6 +26,7 @@ headlinkcolor = #aaaaaa
 codebgcolor = #eeffcc
 codetextcolor = #333333
 
+hosted_on =
 issues_url =
 license_url =
 root_name = Python


### PR DESCRIPTION
Helps https://github.com/python/docs-community/issues/5.

If `hosted_on` is defined in your docs' `conf.py`:

```python
html_theme_options = {
    'collapsiblesidebar': True,
    'hosted_on': '<a href="https://example.com">Example</a>',
    'issues_url': '/bugs.html',
    'license_url': '/license.html',
    'root_include_title': False   # We use the version switcher instead.
}
```

Adds a "Hosted by" line to the footer:

![image](https://github.com/python/python-docs-theme/assets/1324225/d4832366-545c-4c36-a7fa-ed6d05ebf66a)

# Conditional

For https://github.com/python/docs-community/issues/5, we can instead add this in `conf.py`:

```python
if os.getenv("READTHEDOCS"):
    html_theme_options["hosted_on"] = '<a href="https://about.readthedocs.com/">Read the Docs</a>'
```

And we'll only get the "Hosted by" line for [builds created on Read the Docs](https://docs.readthedocs.io/en/stable/reference/environment-variables.html):

![image](https://github.com/python/python-docs-theme/assets/1324225/d611a9a9-8333-4b23-bd9d-37af525d0297)

Here's a demo build:

* https://hugovk-cpython.readthedocs.io/en/hosted-on/
* https://github.com/hugovk/cpython/tree/hosted-on

If you build that locally or on another server which doesn't have the env var defined, we don't get the link:

![image](https://github.com/python/python-docs-theme/assets/1324225/83336492-090a-4a00-8470-c1510436ca0f)


