### PR TITLE
Reduce underline offset

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -31,7 +31,7 @@ pre {
 
 a[href] {
     text-decoration: underline 1px;
-    text-underline-offset: 0.2em;
+    text-underline-offset: 0.25em;
 }
 
 body {

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -31,7 +31,7 @@ pre {
 
 a[href] {
     text-decoration: underline 1px;
-    text-underline-offset: 0.3em;
+    text-underline-offset: 0.2em;
 }
 
 body {


### PR DESCRIPTION
We added underlines in https://github.com/python/python-docs-theme/pull/160, with an offset to make sure they don't obscure underscores in code formatting. With fresh eyes, 0.3em looks a bit too much. Let's reduce it.

# 0.3em

![image](https://github.com/python/python-docs-theme/assets/1324225/6e042058-ea9d-4c3b-aab0-fcbfe659b848)

# 0.2em

![image](https://github.com/python/python-docs-theme/assets/1324225/3488f11f-9d57-451d-b37c-71009387c19b)
