### PR TITLE
Only apply underline offset to code formatting for underline visibility

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -38,6 +38,7 @@ a[href] {
 a[href]:has(> code) {
     text-underline-offset: 0.25em;
 }
+
 /* No underline for navigation */
 a.headerlink,
 div.genindex-jumpbox a,

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -29,10 +29,12 @@ pre {
     color: inherit;
 }
 
+/* Add underlines to links */
 a[href] {
     text-decoration: underline 1px;
 }
 
+/* Increase the underline offset for code to avoid obscuring underscores */
 a[href]:has(> code) {
     text-underline-offset: 0.25em;
 }

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -34,7 +34,6 @@ a[href] {
 
 a[href]:has(> code) {
     text-underline-offset: 0.25em;
-    color: red;
 }
 
 body {

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -31,7 +31,10 @@ pre {
 
 a[href] {
     text-decoration: underline 1px;
+
+a[href]:has(> code) {
     text-underline-offset: 0.25em;
+    color: red;
 }
 
 body {

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -31,6 +31,7 @@ pre {
 
 a[href] {
     text-decoration: underline 1px;
+}
 
 a[href]:has(> code) {
     text-underline-offset: 0.25em;


### PR DESCRIPTION
Helps https://github.com/python/python-docs-theme/issues/168.

In #160 we added underlines to links, with an extra offset to help make sure underscores (`_`) are not obscured by the underlines.

(In https://github.com/python/python-docs-theme/pull/166 we reduced the amount of offset.)

We only really need the offset for code formatting, where underscores often show up, so we can use the default offset for normal links and only apply an extra offset for code.