### PR TITLE
Modernise font: use system font stack to improve text readability and webpage performance

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -170,7 +170,7 @@ div.sphinxsidebar a:hover {
 form.inline-search input,
 div.sphinxsidebar input,
 div.related input {
-    font-family: 'Lucida Grande', Arial, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
     border: 1px solid #999999;
     font-size: smaller;
     border-radius: 3px;
@@ -258,7 +258,7 @@ div.body a:hover {
 }
 
 tt, code, pre {
-    font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Liberation Mono", Menlo, Monaco, Consolas, monospace;
+    font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;
     font-size: 96.5%;
 }
 
@@ -362,7 +362,7 @@ div.genindex-jumpbox a {
     top: 0;
     right: 0;
     text-size: 75%;
-    font-family: monospace;
+    font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;
     padding-left: 0.2em;
     padding-right: 0.2em;
     border-radius: 0 3px 0 0;

--- a/python_docs_theme/theme.conf
+++ b/python_docs_theme/theme.conf
@@ -5,8 +5,8 @@ pygments_style = default
 pygments_dark_style = monokai
 
 [options]
-bodyfont = 'Lucida Grande', Arial, sans-serif
-headfont = 'Lucida Grande', Arial, sans-serif
+bodyfont = -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif
+headfont = -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif
 footerbgcolor = white
 footertextcolor = #555555
 relbarbgcolor = white


### PR DESCRIPTION
The primary font used for by this theme is [Lucida Grande](https://en.wikipedia.org/wiki/Lucida_Grande).

By default, this is only used on macOS:

<details>
<summary>macOS</summary>

<img width="1582" alt="macOS" src="https://github.com/python/python-docs-theme/assets/1324225/cda7366e-bc15-4e31-9333-b32c1574259c">


</details>

On other platforms, the browser uses the more common Arial:

<details>
<summary>Windows, Linux, Android, iPhone</summary>

| Windows | Linux | Android | iPhone |
|  - | - | - | - |
| ![Windows](https://github.com/python/python-docs-theme/assets/1324225/3a0e906d-778a-4e49-b465-e0fea896ffd3) | ![Linux](https://github.com/python/python-docs-theme/assets/1324225/4e14fcf7-dca3-4228-aad9-ae376949d608) | ![Android](https://github.com/python/python-docs-theme/assets/1324225/fd97db03-290d-4aff-a745-e21e540641bf) | ![iPhone](https://github.com/python/python-docs-theme/assets/1324225/a211d643-0336-4952-a5c6-f4278f6668e3) |


</details>

# History

Lucida Grande used to be the system font on Macs from 1999 to 2014, and was used by websites such as apple.com, facebook.com and twitter.com.

* In OS X Yosemite 10.10 (released in 2014), Apple changed the system font to [Helvetica Neue](https://en.wikipedia.org/wiki/Helvetica#Neue_Helvetica_(1983)) (much closer to Arial).
* In OS X El Capitan 10.11 (released in 2015), Apple changed it to [San Francisco](https://en.wikipedia.org/wiki/San_Francisco_(sans-serif_typeface)).

I can't think of any other big websites still using Lucida Grande. To me it looks dated, and I find it hard to read.

# System font stack

I recommend we update to the so-called "system font stack".

Benefits according to https://systemfontstack.com:

* Fast: No network request, no time to parse a font, no flash of an incorrect font.
* Styles & unicode: System fonts have lots of styles and broad language coverage, unlike many webfonts.
* Familiarity: Web apps feel more native when they use system font faces.

Many sites use a system font stack: 
* [GitHub](https://markdotto.com/2018/02/07/github-system-fonts/)
* [Stack Overflow](https://meta.stackexchange.com/q/364048/162511)
* [Booking.com](https://booking.design/implementing-system-fonts-on-booking-com-a-lesson-learned-bdc984df627f)
* [Weather.com, Bootstrap, Medium, Ghost, PubMed, and the WordPress dashboard](https://woorkup.com/system-font/)
* [Furo](https://github.com/pradyunsg/furo/blob/3c4e94897b764a0e25bf6bcf7dd74356009918fe/src/furo/assets/styles/variables/_fonts.scss#L8) theme (used on the [devguide](https://devguide.python.org/))
* [PyData Sphinx Theme](https://github.com/pydata/pydata-sphinx-theme/pull/285#issuecomment-730571293)
* https://peps.python.org/: [python/peps#3132](https://github.com/python/peps/pull/3132)

See more on the [history and rationale](https://medium.com/web-dev-survey-from-kyoto/survey-system-font-stack-5f73a3b39776).

# Preview

<details>
<summary>macOS</summary>

<img width="1582" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/59f3c628-a564-499f-8959-38573eaeecf2">

</details>

https://python-docs-theme-previews--176.org.readthedocs.build/en/176/