### PR TITLE
Don't test theme on 3.8 and 3.9 branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ["origin/main", "3.12", "3.11", "3.10", "3.9", "3.8"]
+        branch: ["origin/main", "3.12", "3.11", "3.10"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Some time between 9th Feb and today, the CI test build have started failing:

* Pass: https://github.com/python/python-docs-theme/actions/runs/7848665626
* Fail: https://github.com/python/python-docs-theme/actions/runs/8306890402

There's been no changes in this repo.

Logs:

```
2024-03-16 09:42:45,381 DEBUG: Starting new HTTPS connection (1): raw.githubusercontent.com:443
2024-03-16 09:42:45,421 DEBUG: https://raw.githubusercontent.com:443 "GET /python/devguide/main/include/release-cycle.json HTTP/1.1" 200 601
2024-03-16 09:42:45,452 INFO: Cloning https://github.com/python/cpython.git into /home/runner/work/python-docs-theme/python-docs-theme/build_root/cpython
2024-03-16 09:42:45,452 DEBUG: Run: 'git clone https://github.com/python/cpython.git /home/runner/work/python-docs-theme/python-docs-theme/build_root/cpython'
2024-03-16 09:43:35,897 INFO en/3.9: Running.
2024-03-16 09:43:35,897 DEBUG en/3.9: Run: 'git -C /home/runner/work/python-docs-theme/python-docs-theme/build_root/cpython show-ref -s origin/3.9'
2024-03-16 09:43:35,900 DEBUG en/3.9: Run: 'git -C /home/runner/work/python-docs-theme/python-docs-theme/build_root/cpython reset --hard 200762426b4b9878c33cdef620aa1a51631dd5df --'
2024-03-16 09:43:36,701 DEBUG en/3.9: Run: 'git -C /home/runner/work/python-docs-theme/python-docs-theme/build_root/cpython clean -dfqx'
2024-03-16 09:43:36,710 INFO en/3.9: Should rebuild: no previous state found.
2024-03-16 09:43:36,711 DEBUG en/3.9: Run: '/opt/hostedtoolcache/Python/3.12.2/x64/bin/python -m venv /home/runner/work/python-docs-theme/python-docs-theme/build_root/venv-3.9'
2024-03-16 09:43:40,007 DEBUG en/3.9: Run: '/home/runner/work/python-docs-theme/python-docs-theme/build_root/venv-3.9/bin/python -m pip install --upgrade /home/runner/work/python-docs-theme/python-docs-theme jieba -rrequirements.txt'
2024-03-16 09:43:44,866 ERROR en/3.9: Run: '/home/runner/work/python-docs-theme/python-docs-theme/build_root/venv-3.9/bin/python -m pip install --upgrade /home/runner/work/python-docs-theme/python-docs-theme jieba -rrequirements.txt' KO:
    Collecting docutils==0.17.1 (from -r requirements.txt (line 10))
      Downloading docutils-0.17.1-py2.py3-none-any.whl.metadata (2.9 kB)
    Collecting jinja2==3.0.3 (from -r requirements.txt (line 12))
      Downloading Jinja2-3.0.3-py3-none-any.whl.metadata (3.5 kB)
    Collecting alabaster==0.7.13 (from -r requirements.txt (line 14))
      Downloading alabaster-0.7.13-py3-none-any.whl.metadata (3.0 kB)
    Collecting blurb (from -r requirements.txt (line 16))
      Downloading blurb-1.1.0-py3-none-any.whl.metadata (9.7 kB)
    ERROR: Cannot install python-docs-theme 2024.2 (from /home/runner/work/python-docs-theme/python-docs-theme) and python-docs-theme==2023.3.1 because these package versions have conflicting dependencies.
    
    The conflict is caused by:
        The user requested python-docs-theme 2024.2 (from /home/runner/work/python-docs-theme/python-docs-theme)
        The user requested python-docs-theme==2023.3.1

    To fix this you could try to:
    1. loosen the range of package versions you've specified
    2. remove package versions to allow pip attempt to solve the dependency conflict

    ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
    
2024-03-16 09:43:44,884 ERROR en/3.9: Badly handled exception, human, please help.
Traceback (most recent call last):
  File "/home/runner/work/python-docs-theme/python-docs-theme/./docsbuild-scripts/build_docs.py", line 658, in run
    self.build_venv()
  File "/home/runner/work/python-docs-theme/python-docs-theme/./docsbuild-scripts/build_docs.py", line 794, in build_venv
    run(
  File "/home/runner/work/python-docs-theme/python-docs-theme/./docsbuild-scripts/build_docs.py", line 251, in run
    result.check_returncode()
  File "/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/subprocess.py", line 502, in check_returncode
    raise CalledProcessError(self.returncode, self.args, self.stdout,
subprocess.CalledProcessError: Command '['/home/runner/work/python-docs-theme/python-docs-theme/build_root/venv-3.9/bin/python', '-m', 'pip', 'install', '--upgrade', '/home/runner/work/python-docs-theme/python-docs-theme', 'jieba', '-rrequirements.txt']' returned non-zero exit status 1.
2024-03-16 09:43:44,907 INFO: Skipping sitemap generation (www root does not even exists).
2024-03-16 09:43:44,907 INFO: Skipping 404 page generation (www root does not even exists).
2024-03-16 09:43:44,907 INFO: Skipping robots.txt generation (www root does not even exists).
```

This is because we have pinned the theme used in CPython 3.8 and 3.9 branches to 2023.3.1 to fix https://github.com/python/cpython/issues/115349 (PR https://github.com/python/cpython/pull/115351 and https://github.com/python/cpython/pull/115404).

Therefore we no longer need to test the latest version of this theme on the 3.8 and 3.8 branches.