### PR TITLE
Unset default list style

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -29,6 +29,11 @@ pre {
     color: inherit;
 }
 
+/* Unset default list style */
+ul {
+    list-style-type: none;
+}
+
 /* Add underlines to links */
 a[href] {
     text-decoration: underline 1px;

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -34,6 +34,10 @@ ul {
     list-style-type: none;
 }
 
+ul.simple {
+    list-style-type: initial;
+}
+
 /* Add underlines to links */
 a[href] {
     text-decoration: underline 1px;
@@ -342,7 +346,7 @@ dl > dt span ~ em,
 }
 
 .toctree-wrapper ul {
-    padding-left: 20px;
+    padding-left: 10px;
 }
 
 .theme-selector {


### PR DESCRIPTION
Clean up unnecessary symbols, leading to improvement in the content readability.
Before:
![image](https://github.com/python/python-docs-theme/assets/39376984/d34ceff3-3c06-4a73-aa6c-bf5ce49e5ffa)

After:
![image](https://github.com/python/python-docs-theme/assets/39376984/e2efa7e5-bced-4fde-91d1-40a715a77bf7)

Preview: https://python-docs-theme-previews--179.org.readthedocs.build/en/179/tutorial/index.html

Before: https://python-docs-theme-previews.readthedocs.io/en/latest/tutorial/index.html