### PR TITLE
Exclude bots from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
Like https://github.com/tox-dev/tox-ini-fmt/pull/120.

When drafting a release and generating the release notes (see https://github.com/python/python-docs-theme/blob/main/CONTRIBUTING.rst), by default Dependabot and pre-commit are included.

I edited them out when preparing https://github.com/python/python-docs-theme/releases/tag/2024.3, but let's add config to exclude them.

Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options