### PR TITLE
Only show 'Last updated on ...' when `last_updated` defined

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -136,14 +136,24 @@
 
 {% block footer %}
     <div class="footer">
-    &copy; {% if theme_copyright_url or hasdoc('copyright') %}<a href="{% if theme_copyright_url %}{{ theme_copyright_url }}{% else %}{{ pathto('copyright') }}{% endif %}">{% endif %}{% trans %}Copyright{% endtrans %}{% if theme_copyright_url or hasdoc('copyright') %}</a>{% endif %} {{ copyright|e }}.
+    &copy; {% if theme_copyright_url or hasdoc('copyright') %}
+      <a href="{% if theme_copyright_url %}{{ theme_copyright_url }}{% else %}{{ pathto('copyright') }}{% endif %}">
+    {% endif %}
+    {% trans %}Copyright{% endtrans %}
+    {% if theme_copyright_url or hasdoc('copyright') %}
+      </a>
+    {% endif %} {{ copyright|e }}.
     <br />
     {% trans %}This page is licensed under the Python Software Foundation License Version 2.{% endtrans %}
     <br />
     {% trans %}Examples, recipes, and other code in the documentation are additionally licensed under the Zero Clause BSD License.{% endtrans %}
     <br />
-    {% if theme_license_url %}{% trans license_file=theme_license_url %}See <a href="{{ license_file }}">History and License</a> for more information.{% endtrans %}<br />{% endif %}
-    {% if theme_hosted_on %}{% trans hosted_on=theme_hosted_on %}Hosted on {{ hosted_on }}.{% endtrans %}<br />{% endif %}
+    {% if theme_license_url %}
+      {% trans license_file=theme_license_url %}See <a href="{{ license_file }}">History and License</a> for more information.{% endtrans %}<br />
+    {% endif %}
+    {% if theme_hosted_on %}
+      {% trans hosted_on=theme_hosted_on %}Hosted on {{ hosted_on }}.{% endtrans %}<br />
+    {% endif %}
     <br />
 
     {% include "footerdonate.html" %}
@@ -152,7 +162,9 @@
     {%- if last_updated %}
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
     {%- endif %}
-    {% if theme_issues_url %}{% trans %}<a href="{{ theme_issues_url }}">Found a bug</a>?{% endtrans %}{% endif %}
+    {% if theme_issues_url %}
+      {% trans %}<a href="{{ theme_issues_url }}">Found a bug</a>?{% endtrans %}
+    {% endif %}
     <br />
 
     {% trans sphinx_version=sphinx_version|e %}Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}

--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -149,7 +149,9 @@
     {% include "footerdonate.html" %}
     <br />
 
-    {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
+    {%- if last_updated %}
+      {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
+    {%- endif %}
     {% if theme_issues_url %}{% trans %}<a href="{{ theme_issues_url }}">Found a bug</a>?{% endtrans %}{% endif %}
     <br />
 


### PR DESCRIPTION
Fixes https://github.com/python/python-docs-theme/issues/182.

We were always showing it:
```jinja
{% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
```

Instead, we should check the variable first:
```jinja
{%- if last_updated %}
  {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
{%- endif %}
```

This is also what Sphinx does:

https://github.com/sphinx-doc/sphinx/blob/2e05fd2ffe70b2cfd48bdb9e35eecac43b46637d/sphinx/themes/basic/layout.html#L211-L213

Also add some newlines around other `if` blocks to make them clearer.
