### PR TITLE
Link to kitchen sink demo in README and convert to Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Python Docs Sphinx Theme
-=========================
+# Python Docs Sphinx Theme
 
 This is the theme for the Python documentation.
 
@@ -10,21 +9,19 @@ projects if you so choose, but please keep in mind that in doing so you're also
 choosing to accept some of the responsibility for maintaining that collective
 trust.
 
-To use the theme, install it into your docs build environment via ``pip``
+To use the theme, install it into your docs build environment via `pip`
 (preferably in a virtual environment).
 
 
-Configuration options
----------------------
+## Configuration options
 
-To use this theme, add the following to ``conf.py``:
+To use this theme, add the following to `conf.py`:
 
-- ``html_theme = 'python_docs_theme'``
+- `html_theme = 'python_docs_theme'`
 
-- ``html_sidebars``, defaults taken from https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_sidebars
+- `html_sidebars`, defaults taken from https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_sidebars
 
-Preview
--------
+## Preview
 
 See a demo of the CPython docs using this theme:
 

--- a/README.rst
+++ b/README.rst
@@ -29,3 +29,7 @@ Preview
 See a demo of the CPython docs using this theme:
 
 - https://python-docs-theme-previews.readthedocs.io
+
+The kitchen sink is a showcase of every Sphinx feature:
+
+- https://sphinx-themes.org/sample-sites/python-docs-theme/kitchen-sink/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 name = "python-docs-theme"
 version = "2024.3"
 description = "The Sphinx theme for the CPython docs and related projects"
-readme = "README.rst"
+readme = "README.md"
 license.file = "LICENSE"
 authors = [{name = "PyPA", email = "distutils-sig@python.org"}]
 requires-python = ">=3.8"


### PR DESCRIPTION
https://sphinx-themes.org has sample builds of many Sphinx themes, including this one.

They have a very handy "kitchen sink" to demo all the Sphinx features, so we can easily see things like admonitions, lists, structure and so on.

https://sphinx-themes.org/sample-sites/python-docs-theme/kitchen-sink/

Also convert the README to Markdown, we don't need the full complexity of reStructuredText here.