### PR TITLE
Add colour to version change directives

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -622,3 +622,50 @@ div.genindex-jumpbox a {
         margin-top: -2em;
     }
 }
+
+/* Version change directives */
+:root {
+    --versionadded: rgb(41 100 51);
+    --versionchanged: rgb(133 72 38);
+    --deprecated: rgb(159 49 51);
+
+    --versionadded-border: rgb(79 196 100);
+    --versionchanged-border: rgb(244, 227, 76);
+    --deprecated-border: rgb(244, 76, 78);
+}
+
+div.versionadded,
+div.versionchanged,
+div.deprecated,
+div.deprecated-removed {
+    border-left: 3px solid;
+    padding: 0 1rem;
+}
+
+div.versionadded {
+    border-left-color: var(--versionadded-border);
+}
+
+div.versionchanged {
+    border-left-color: var(--versionchanged-border);
+}
+
+div.deprecated,
+div.deprecated-removed,
+div.versionremoved {
+    border-left-color: var(--deprecated-border);
+}
+
+div.versionadded .versionmodified {
+    color: var(--versionadded);
+}
+
+div.versionchanged .versionmodified {
+    color: var(--versionchanged);
+}
+
+div.deprecated .versionmodified,
+div.deprecated-removed .versionmodified,
+div.versionremoved .versionmodified {
+    color: var(--deprecated);
+}

--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -140,3 +140,10 @@ img.invert-in-dark-mode {
 .sig.cpp .k, .sig.cpp .kt {
     color: #5283ff;
 }
+
+/* Version change directives */
+:root {
+    --versionadded: rgb(79 196 100);
+    --versionchanged: rgb(244, 227, 76);
+    --deprecated: rgb(244, 76, 78);
+}


### PR DESCRIPTION
Similar to the sidebars in [PEP 7](https://peps.python.org/pep-0007/) and [PEP 8](https://peps.python.org/pep-0008/), we can add coloured sidebars and text to the version change directives.

## Dark theme

<img width="799" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/9ab2800b-c4f1-4ab6-83e8-fbe59e616703">

## Light theme

<img width="802" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/b60456f8-5e69-4494-b474-640fbdb1524f">

## Accessibility check

* We're not relying on the colour in the sidebar or text to convey meaning. The words remains as before.
* The text like "Changed in version x.y" is now in colour. The contrast ratio meets at least the WCAG AA guidelines (4.5), with all but one meeting AAA (7.0).
* In dark mode, the same colour is used for the sidebar and the text:
  * Green: 7.13 (AAA)
  * Yellow: 12.07 (AAA)
  * Red: 4.53 (AA)
* In light mode, the sidebar colour is the same as in dark mode. The text needs to be darker to be readable:
  * Green: 7.08 (AAA)
  * Orange: 7.11 (AAA)
  * Red: 7.09 (AAA)


## `versionremoved`

I also pre-emptively applied the red styling for the `versionremoved` directive, which will be released in the next Sphinx 7.3.0 ([https://github.com/sphinx-doc/sphinx/pull/11905](https://github.com/sphinx-doc/sphinx/pull/11905)).

## Comparison with other themes

This is similar to how the [Awesome](https://sphinx-themes.org/sample-sites/sphinxawesome-theme/kitchen-sink/admonitions/#versionadded) theme does it.

These themes also add a background colour:

* [Sphinx Book Theme](https://sphinx-themes.org/sample-sites/sphinx-book-theme/kitchen-sink/admonitions/#versionadded) 
* [PyData Sphinx Theme](https://sphinx-themes.org/sample-sites/pydata-sphinx-theme/kitchen-sink/admonitions/#versionadded) 
* [Sphinx theme for Wagtail](https://sphinx-themes.org/sample-sites/sphinx-wagtail-theme/kitchen-sink/admonitions/#versionadded) 

And [Nefertiti for Sphinx](https://sphinx-themes.org/sample-sites/sphinx-nefertiti/kitchen-sink/admonitions/#versionadded) adds a coloured box around it.