### PR TITLE
Use system font stack

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -333,7 +333,7 @@ div.footer a:hover {
 
 dl > dt span ~ em,
 .sig {
-    font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Liberation Mono", Menlo, Monaco, Consolas, monospace;
+    font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;
 }
 
 .toctree-wrapper ul {


### PR DESCRIPTION
Follow on from https://github.com/python/python-docs-theme/pull/176.

I missed one of the code font styles.

It's subtle but can be seen in this table:

* https://docs.python.org/3.13/library/asyncio-task.html#waiting-primitives

The left column has the old font (e.g. `asyncio.FIRST_COMPLETED`), but the right has the new one (e.g. the `ALL_COMPLETED` link).

Preview:

* https://python-docs-theme-previews--186.org.readthedocs.build/en/186/library/asyncio-task.html#waiting-primitives