### PR TITLE
Use different colour for 'Return value: Borrowed reference'

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -1,5 +1,15 @@
 @import url('classic.css');
 
+/* Common colours */
+:root {
+    --good-color: rgb(41 100 51);
+    --good-border: rgb(79 196 100);
+    --middle-color: rgb(133 72 38);
+    --middle-border: rgb(244, 227, 76);
+    --bad-color: rgb(159 49 51);
+    --bad-border: rgb(244, 76, 78);
+}
+
 /* unset some styles from the classic stylesheet */
 div.document,
 div.body,
@@ -325,8 +335,8 @@ div.footer a:hover {
 
 /* C API return value annotations */
 :root {
-    --refcount: #060;
-    --refcount-return-borrowed-ref: rgb(133 72 38);
+    --refcount: var(--good-color);
+    --refcount-return-borrowed-ref: var(--middle-color);
 }
 
 .refcount {
@@ -635,13 +645,13 @@ div.genindex-jumpbox a {
 
 /* Version change directives */
 :root {
-    --versionadded: rgb(41 100 51);
-    --versionchanged: rgb(133 72 38);
-    --deprecated: rgb(159 49 51);
+    --versionadded: var(--good-color);
+    --versionchanged: var(--middle-color);
+    --deprecated: var(--bad-color);
 
-    --versionadded-border: rgb(79 196 100);
-    --versionchanged-border: rgb(244, 227, 76);
-    --deprecated-border: rgb(244, 76, 78);
+    --versionadded-border: var(--good-border);
+    --versionchanged-border: var(--middle-border);
+    --deprecated-border: var(--bad-border);
 }
 
 div.versionadded,

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -323,8 +323,18 @@ div.footer a:hover {
     color: #0095c4;
 }
 
+/* C API return value annotations */
+:root {
+    --refcount: #060;
+    --refcount-return-borrowed-ref: rgb(133 72 38);
+}
+
 .refcount {
-    color: #060;
+    color: var(--refcount);
+}
+
+.refcount.return_borrowed_ref {
+    color: var(--refcount-return-borrowed-ref)
 }
 
 .stableabi {

--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -1,3 +1,13 @@
+/* Common colours */
+:root {
+    --good-color: rgb(79 196 100);
+    --good-border: var(--good-color);
+    --middle-color: rgb(244, 227, 76);
+    --middle-border: var(--middle-color);
+    --bad-color: rgb(244, 76, 78);
+    --bad-border: var(--bad-color);
+}
+
 
 /* Browser elements */
 :root {
@@ -79,13 +89,6 @@ table.docutils th {
     background-color: #424242;
 }
 
-/* C API return value annotations */
-
-:root {
-    --refcount: #afa;
-    --refcount-return-borrowed-ref: rgb(244, 227, 76);
-}
-
 .stableabi {
     color: #bbf;
 }
@@ -146,7 +149,7 @@ img.invert-in-dark-mode {
 
 /* Version change directives */
 :root {
-    --versionadded: rgb(79 196 100);
-    --versionchanged: rgb(244, 227, 76);
-    --deprecated: rgb(244, 76, 78);
+    --versionadded: var(--good-color);
+    --versionchanged: var(--middle-color);
+    --deprecated: var(--bad-color);
 }

--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -79,8 +79,11 @@ table.docutils th {
     background-color: #424242;
 }
 
-.refcount {
-    color: #afa;
+/* C API return value annotations */
+
+:root {
+    --refcount: #afa;
+    --refcount-return-borrowed-ref: rgb(244, 227, 76);
 }
 
 .stableabi {


### PR DESCRIPTION
Follow on from https://github.com/python/cpython/pull/117926.

Currently light green is used for all return types:

* "Return value: Always NULL."
* "Return value: New reference."
* "Return value: Borrowed reference."

For example: https://docs.python.org/3/c-api/exceptions.html

![image](https://github.com/python/cpython/assets/1324225/e30b3c6f-2df7-48fa-8227-5d4cb5cc0c4a)

![image](https://github.com/python/cpython/assets/1324225/2a680697-1343-4418-8fb1-9f803fe5b91f)

![image](https://github.com/python/cpython/assets/1324225/128db93a-5397-4fea-ad69-369fde837be5)

A borrowed reference is not necessarily a "bad" thing, but we may want to use something other than green that indicates it's "good", to indicate they should be treated with care.

This PR uses the same yellow/orange colour as the "Changed in version x.y" text in https://github.com/python/python-docs-theme/pull/185 - I've already checked the contrast ratios in that PR and both meet WCAG AAA. By using the same colour, it will be easier to check/change when we audit.

<img width="804" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/1d851996-9bb0-4ec3-987a-ddc6f2d313e8">

<img width="815" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/d89bcf14-af8d-4ca6-b904-7008afbeadea">

For example: https://python-docs-theme-previews--188.org.readthedocs.build/en/188/c-api/exceptions.html#querying-the-error-indicator
