### PR TITLE
Replace Flake8 with Ruff and add more linting for GitHub Actions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 88

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,9 @@ jobs:
           --build-root ./build_root
           --www-root ./www
           --log-directory ./logs
-          --group $(id -g)
+          --group "$(id -g)"
           --skip-cache-invalidation
-          --theme $(pwd)
+          --theme "$(pwd)"
           --language en
           --branch ${{ matrix.branch }}
       - name: Show logs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,17 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.2
+    hooks:
+      - id: check-dependabot
+      - id: check-github-workflows
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.6.27
+    hooks:
+      - id: actionlint
+
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: 1.8.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,17 @@
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.0
     hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
+      - id: ruff
+        args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
+    rev: 24.4.0
     hooks:
       - id: black
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          [flake8-2020, flake8-implicit-str-concat, flake8-logging]
-
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-      - id: python-check-blanket-noqa
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -39,7 +22,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 1.7.0
+    rev: 1.8.0
     hooks:
       - id: pyproject-fmt
         args: [--max-supported-python=3.13]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,32 @@ include = [
     "python_docs_theme/",
 ]
 
-[tool.isort]
-add_imports = "from __future__ import annotations"
-profile = "black"
+[tool.ruff]
+fix = true
+
+[tool.ruff.lint]
+select = [
+  "C4",     # flake8-comprehensions
+  "E",      # pycodestyle errors
+  "F",      # pyflakes errors
+  "I",      # isort
+  "ISC",    # flake8-implicit-str-concat
+  "LOG",    # flake8-logging
+  "PGH",    # pygrep-hooks
+  "PYI",    # flake8-pyi
+  "RUF100", # unused noqa (yesqa)
+  "RUF022", # unsorted-dunder-all
+  "UP",     # pyupgrade
+  "W",      # pycodestyle warnings
+  "YTT",    # flake8-2020
+]
+ignore = [
+  "E203",   # Whitespace before ':'
+  "E221",   # Multiple spaces before operator
+  "E226",   # Missing whitespace around arithmetic operator
+  "E241",   # Multiple spaces after ','
+]
+
+
+[tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]

--- a/python_docs_theme/__init__.py
+++ b/python_docs_theme/__init__.py
@@ -24,7 +24,7 @@ def _asset_hash(path: str) -> str:
 def _add_asset_hashes(static: list[str], add_digest_to: list[str]) -> None:
     for asset in add_digest_to:
         index = static.index(asset)
-        static[index].filename = _asset_hash(asset)  # type: ignore
+        static[index].filename = _asset_hash(asset)  # type: ignore[attr-defined]
 
 
 def _html_page_context(


### PR DESCRIPTION
* Replace Flake8 + isort + pygrep-hooks with Ruff
* Add check-jsonschema to lint YAML and actionlint for GitHub Actions
* Fix shellcheck SC2046: Quote to prevent word splitting
