### PR TITLE
Add backgrounds and borders to admonitions

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -250,7 +250,7 @@ div.body pre {
     --attention-background: #bbddff5c;
     --attention-border: #0000ff36;
     --caution-background: #ffc;
-    --caution-border: #dddd66;
+    --caution-border: #dd6;
     --danger-background: #ffe4e4;
     --danger-border: red;
     --error-background: #ffe4e4;
@@ -258,7 +258,7 @@ div.body pre {
     --hint-background: #dfd;
     --hint-border: green;
     --seealso-background: #ffc;
-    --seealso-border: #dddd66;
+    --seealso-border: #dd6;
     --tip-background: #dfd;
     --tip-border: green;
     --warning-background: #ffe4e4;

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -242,17 +242,80 @@ div.body pre {
     border: 1px solid #ac9;
 }
 
-div.body div.admonition,
+/* Admonitions */
+:root {
+    --admonition-background: #eee;
+    --admonition-border: #ccc;
+    --attention-background: #bbddff5c;
+    --attention-border: #0000ff36;
+    --caution-background: #ffc;
+    --caution-border: #dddd66;
+    --danger-background: #ffe4e4;
+    --danger-border: red;
+    --error-background: #ffe4e4;
+    --error-border: red;
+    --hint-background: #bfc;
+    --hint-border: green;
+    --seealso-background: #ffc;
+    --seealso-border: #dddd66;
+    --tip-background: #bfc;
+    --tip-border: green;
+    --warning-background: #ffe4e4;
+    --warning-border: red;
+}
+
+div.body div.admonition {
+    background-color: var(--admonition-background);
+    border-radius: 3px;
+    border: 1px solid var(--admonition-border);
+}
+
+div.body div.admonition.attention {
+    background-color: var(--attention-background);
+    border-color: var(--attention-border);
+}
+
+div.body div.admonition.caution {
+    background-color: var(--caution-background);
+    border-color: var(--caution-border);
+}
+
+div.body div.admonition.danger {
+    background-color: var(--danger-background);
+    border-color: var(--danger-border);
+}
+
+div.body div.admonition.error {
+    background-color: var(--error-background);
+    border-color: var(--error-border);
+}
+
+div.body div.admonition.hint {
+    background-color: var(--hint-background);
+    border-color: var(--hint-border);
+}
+
+div.body div.admonition.seealso {
+    background-color: var(--seealso-background);
+    border-color: var(--seealso-border);
+}
+
+div.body div.admonition.tip {
+    background-color: var(--tip-background);
+    border-color: var(--tip-border);
+}
+
+div.body div.admonition.warning {
+    background-color: var(--warning-background);
+    border-color: var(--warning-border);
+}
+
 div.body div.impl-detail {
     border-radius: 3px;
 }
 
 div.body div.impl-detail > p {
     margin: 0;
-}
-
-div.body div.seealso {
-    border: 1px solid #dddd66;
 }
 
 div.body a {

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -246,6 +246,7 @@ div.body pre {
 :root {
     --admonition-background: #eee;
     --admonition-border: #ccc;
+    --admonition-color: black;
     --attention-background: #bbddff5c;
     --attention-border: #0000ff36;
     --caution-background: #ffc;
@@ -268,6 +269,7 @@ div.body div.admonition {
     background-color: var(--admonition-background);
     border: 1px solid var(--admonition-border);
     border-radius: 3px;
+    color: var(--admonition-color);
 }
 
 div.body div.admonition.attention {

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -254,11 +254,11 @@ div.body pre {
     --danger-border: red;
     --error-background: #ffe4e4;
     --error-border: red;
-    --hint-background: #bfc;
+    --hint-background: #dfd;
     --hint-border: green;
     --seealso-background: #ffc;
     --seealso-border: #dddd66;
-    --tip-background: #bfc;
+    --tip-background: #dfd;
     --tip-border: green;
     --warning-background: #ffe4e4;
     --warning-border: red;

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -266,8 +266,8 @@ div.body pre {
 
 div.body div.admonition {
     background-color: var(--admonition-background);
-    border-radius: 3px;
     border: 1px solid var(--admonition-border);
+    border-radius: 3px;
 }
 
 div.body div.admonition.attention {

--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -113,6 +113,28 @@ div.warning {
     background-color: rgba(255, 0, 0, 0.5);
 }
 
+/* Admonitions */
+:root {
+    --admonition-background: rgba(255, 255, 255, 0.1);
+    --admonition-border: currentColor;
+    --attention-background: rgba(255, 255, 255, 0.1);
+    --attention-border: currentColor;
+    --caution-background: rgba(255, 255, 0, 0.1);
+    --caution-border: #dd6;
+    --danger-background: rgba(255, 0, 0, 0.2);
+    --danger-border: #f66;
+    --error-background: rgba(255, 0, 0, 0.2);
+    --error-border: #f66;
+    --hint-background: #0044117a;
+    --hint-border: green;
+    --seealso-background: rgba(255, 255, 0, 0.1);
+    --seealso-border: #dd6;
+    --tip-background: #0044117a;
+    --tip-border: green;
+    --warning-background: rgba(255, 0, 0, 0.2);
+    --warning-border: #f66;
+}
+
 aside.topic,
 div.topic,
 div.note,

--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -115,25 +115,25 @@ div.warning {
 
 /* Admonitions */
 :root {
-    --admonition-background: rgba(255, 255, 255, 0.1);
+    --admonition-background: #ffffff1a;
     --admonition-border: currentColor;
-    --admonition-color: rgba(255, 255, 255, 0.87);
-    --attention-background: rgba(255, 255, 255, 0.1);
+    --admonition-color: #ffffffde;
+    --attention-background: #ffffff1a;
     --attention-border: currentColor;
-    --caution-background: rgba(255, 255, 0, 0.1);
+    --caution-background: #ffff001a;
     --caution-border: #dd6;
-    --danger-background: rgba(255, 0, 0, 0.2);
+    --danger-background: #f003;
     --danger-border: #f66;
-    --error-background: rgba(255, 0, 0, 0.2);
+    --error-background: #f003;
     --error-border: #f66;
     --hint-background: #0044117a;
     --hint-border: green;
-    --seealso-background: rgba(255, 255, 0, 0.1);
+    --seealso-background: #ffff001a;
     --seealso-border: #dd6;
     --tip-background: #0044117a;
     --tip-border: green;
-    --warning-background: rgba(255, 0, 0, 0.2);
-    --warning-border: #f66;
+    --warning-background: #ff000033;
+    --warning-border: #ff6666;
 }
 
 aside.topic,

--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -117,6 +117,7 @@ div.warning {
 :root {
     --admonition-background: rgba(255, 255, 255, 0.1);
     --admonition-border: currentColor;
+    --admonition-color: rgba(255, 255, 255, 0.87);
     --attention-background: rgba(255, 255, 255, 0.1);
     --attention-border: currentColor;
     --caution-background: rgba(255, 255, 0, 0.1);


### PR DESCRIPTION
Only some of the "admonitions" have backgrounds and borders, giving them slightly different indentations:

![image](https://github.com/python/python-docs-theme/assets/1324225/cef71aa6-3aca-4a0b-8fa7-3c762ff2cf0d)

We're missing backgrounds and borders for most of them:

* https://sphinx-themes.org/sample-sites/python-docs-theme/kitchen-sink/admonitions/

Other themes have them for all:

* https://sphinx-themes.org/sample-sites/pydata-sphinx-theme/kitchen-sink/admonitions/
* https://sphinx-themes.org/sample-sites/furo/kitchen-sink/admonitions/
* https://sphinx-themes.org/sample-sites/sphinx-rtd-theme/kitchen-sink/admonitions/
* https://sphinx-themes.org/sample-sites/default-alabaster/kitchen-sink/admonitions/

Let's also fill in the gaps.

# Before

<table>
<tr>
<td><img width="413" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/24689ad0-8687-4f8b-8e0a-39a5b726447d">
<td><img width="414" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/00b99b02-3c8e-41f5-83d9-e048f55678f8">
</table>

# After

<table>
<tr>
<td><img width="415" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/9e7a07b0-5c67-48df-824f-081facb2e35f">
<td><img width="417" alt="image" src="https://github.com/python/python-docs-theme/assets/1324225/03775085-1a2a-43a0-b0ec-878b90bd1fa7">
</table>

Screenshots using this from the [Kitchen Sink](https://github.com/sphinx-themes/sphinx-themes.org/blob/master/sample-docs/kitchen-sink/admonitions.rst?plain=1):

<details>
<summary>Details</summary>

```rst
..
   Copyright (c) 2021 Pradyun Gedam
   Licensed under Creative Commons Attribution-ShareAlike 4.0 International License
   SPDX-License-Identifier: CC-BY-SA-4.0

===========
Admonitions
===========

Sphinx provides several different types of admonitions.

``topic``
=========

.. topic:: This is a topic.

   This is what admonitions are a special case of, according to the docutils
   documentation.

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.

``admonition``
==============

.. admonition:: The one with the custom titles

   It's got a certain charm to it.

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.

``attention``
=============

.. attention::

   Climate change is real.

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.

``caution``
===========

.. caution::

   Cliff ahead: Don't drive off it.

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.

``danger``
==========

.. danger::

   Mad scientist at work!

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.

``error``
=========

.. error::

   Does not compute.

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.

``hint``
========

.. hint::

   Insulators insulate, until they are subject to ______ voltage.

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.

``important``
=============

.. important::

   Tech is not neutral, nor is it apolitical.

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.

``note``
========

.. note::

   This is a note.

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.

``seealso``
===========

.. seealso::

   Other relevant information.

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.

``tip``
=======

.. tip::

   25% if the service is good.

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.

``warning``
===========

.. warning::

   Reader discretion is strongly advised.

   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
```


</details>
