### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "The Sphinx theme for the CPython docs and related projects"
 readme = "README.md"
 license.file = "LICENSE"
 authors = [{name = "PyPA", email = "distutils-sig@python.org"}]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Sphinx :: Theme",
@@ -20,7 +20,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/python_docs_theme/__init__.py
+++ b/python_docs_theme/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-from functools import lru_cache
+from functools import cache
 from pathlib import Path
 from typing import Any
 
@@ -12,7 +12,7 @@ from sphinx.builders.html import StandaloneHTMLBuilder
 THEME_PATH = Path(__file__).parent.resolve()
 
 
-@lru_cache(maxsize=None)
+@cache
 def _asset_hash(path: str) -> str:
     """Append a `?digest=` to an url based on the file content."""
     full_path = THEME_PATH / path.replace("_static/", "static/")


### PR DESCRIPTION
Python 3.8 is end-of-life next month:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/#lifespan
