### PR TITLE
Generate digital attestations for PyPI (PEP 740)

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   # Always build & lint package.
   build-package:
@@ -45,3 +48,5 @@ jobs:
 
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.0
+    rev: v0.6.8
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.0
+    rev: 24.8.0
     hooks:
       - id: black
 
@@ -22,24 +22,24 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.2
+    rev: 0.29.2
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.27
+    rev: v1.7.2
     hooks:
       - id: actionlint
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 1.8.0
+    rev: 2.2.4
     hooks:
       - id: pyproject-fmt
         args: [--max-supported-python=3.13]
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.16
+    rev: v0.20.2
     hooks:
       - id: validate-pyproject
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "flit_core.buildapi"
 requires = [
-  "flit_core>=3.7",
+  "flit-core>=3.7",
 ]
 
 [project]
@@ -10,7 +10,7 @@ version = "2024.6"
 description = "The Sphinx theme for the CPython docs and related projects"
 readme = "README.md"
 license.file = "LICENSE"
-authors = [{name = "PyPA", email = "distutils-sig@python.org"}]
+authors = [ { name = "PyPA", email = "distutils-sig@python.org" } ]
 requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -32,22 +32,18 @@ urls.Code = "https://github.com/python/python-docs-theme"
 urls.Download = "https://pypi.org/project/python-docs-theme/"
 urls.Homepage = "https://github.com/python/python-docs-theme/"
 urls."Issue tracker" = "https://github.com/python/python-docs-theme/issues"
-[project.entry-points."sphinx.html_themes"]
-python_docs_theme = 'python_docs_theme'
+entry-points."sphinx.html_themes".python_docs_theme = "python_docs_theme"
 
 [tool.flit.module]
 name = "python_docs_theme"
 
 [tool.flit.sdist]
-include = [
-    "python_docs_theme/",
-]
+include = [ "python_docs_theme/" ]
 
 [tool.ruff]
 fix = true
 
-[tool.ruff.lint]
-select = [
+lint.select = [
   "C4",     # flake8-comprehensions
   "E",      # pycodestyle errors
   "F",      # pyflakes errors
@@ -56,19 +52,16 @@ select = [
   "LOG",    # flake8-logging
   "PGH",    # pygrep-hooks
   "PYI",    # flake8-pyi
-  "RUF100", # unused noqa (yesqa)
   "RUF022", # unsorted-dunder-all
+  "RUF100", # unused noqa (yesqa)
   "UP",     # pyupgrade
   "W",      # pycodestyle warnings
   "YTT",    # flake8-2020
 ]
-ignore = [
-  "E203",   # Whitespace before ':'
-  "E221",   # Multiple spaces before operator
-  "E226",   # Missing whitespace around arithmetic operator
-  "E241",   # Multiple spaces after ','
+lint.ignore = [
+  "E203", # Whitespace before ':'
+  "E221", # Multiple spaces before operator
+  "E226", # Missing whitespace around arithmetic operator
+  "E241", # Multiple spaces after ','
 ]
-
-
-[tool.ruff.lint.isort]
-required-imports = ["from __future__ import annotations"]
+lint.isort.required-imports = [ "from __future__ import annotations" ]


### PR DESCRIPTION
PEP 740 ("Index support for digital attestations") introduces signatures which links the PyPI package to the GitHub repo, and helps users verify the source and authenticity of packages.

PyPI is still implementing support, but we can already start using it, which should also help them test out.

* https://peps.python.org/pep-0740/
* https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations
* https://github.com/pypi/warehouse/issues/15871
