### PR TITLE
Hide header and search bar when printing

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -754,3 +754,10 @@ div.deprecated-removed .versionmodified,
 div.versionremoved .versionmodified {
     color: var(--deprecated);
 }
+
+/* Hide header when printing */
+@media print {
+    div.mobile-nav {
+        display: none;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/python/python-docs-theme/issues/203.

Using media query for print, hide the header that contains the search bar.