### PR TITLE
Fix PR preview links

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -6,9 +6,6 @@ on:
   pull_request_target:
     types:
       - opened
-    paths:
-    - 'Doc/**'
-    - '.github/workflows/doc.yml'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
This file was copied from CPython and I forgot to remove the `paths` restriction, and it's never run:

https://github.com/python/python-docs-theme/actions/workflows/documentation-links.yml

We always build a preview here, so let's always add the link.