### PR TITLE
Note minimum requirements for Sphinx

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.8
+    rev: v0.9.3
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -22,24 +22,24 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.29.2
+    rev: 0.31.0
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.2
+    rev: v1.7.7
     hooks:
       - id: actionlint
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 2.2.4
+    rev: v2.5.0
     hooks:
       - id: pyproject-fmt
         args: [--max-supported-python=3.13]
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.20.2
+    rev: v0.23
     hooks:
       - id: validate-pyproject
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Python Docs Sphinx Theme
 
 This is the theme for the Python documentation.
+It requires Python 3.9 or newer and Sphinx 3.4 or newer.
 
 Note that when adopting this theme, you're also borrowing an element of the
 trust and credibility established by the CPython core developers over the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ classifiers = [
   "Topic :: Documentation",
   "Topic :: Software Development :: Documentation",
 ]
+dependencies = [
+  "sphinx>=3.4",
+]
+
 urls.Code = "https://github.com/python/python-docs-theme"
 urls.Download = "https://pypi.org/project/python-docs-theme/"
 urls.Homepage = "https://github.com/python/python-docs-theme/"

--- a/python_docs_theme/__init__.py
+++ b/python_docs_theme/__init__.py
@@ -53,6 +53,8 @@ def _html_page_context(
 
 
 def setup(app):
+    app.require_sphinx("3.4")
+
     current_dir = os.path.abspath(os.path.dirname(__file__))
     app.add_html_theme("python_docs_theme", current_dir)
 


### PR DESCRIPTION
We implicitly support the [versions used in CPython](https://github.com/python/docsbuild-scripts?tab=readme-ov-file#check-current-version). However, Python 3.9 uses a pinned version of this theme (https://github.com/python/cpython/pull/115351), so we can explicitly document our minimum supported versions as those used in the Python 3.10 branch.

A

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--216.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->