### PR TITLE
Make sidebar width more flexible

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -140,6 +140,8 @@ span.pre {
 }
 
 div.sphinxsidebar {
+    display: flex;
+    width: 260px;
     float: none;
     position: sticky;
     top: 0;
@@ -156,13 +158,17 @@ div.sphinxsidebar h4 {
     margin-top: 1.5em;
 }
 
+div.documentwrapper > div.bodywrapper {
+    margin-left: 260px;
+}
+
 div.sphinxsidebarwrapper {
-    width: 217px;
     box-sizing: border-box;
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
-    float: left;
+    float: none;
+    flex-grow: 1;
 }
 
 div.sphinxsidebarwrapper > h3:first-child {
@@ -199,10 +205,11 @@ div.sphinxsidebar input[type='text'] {
     font-size: 1.2em;
     cursor: pointer;
     padding-top: 1px;
-    float: right;
+    float: none;
     display: table;
     /* after Sphinx 4.x and earlier is dropped, only the below is needed */
     width: 12px;
+    min-width: 12px;
     border-radius: 0 5px 5px 0;
     border-left: none;
 }

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -158,7 +158,7 @@ div.sphinxsidebar h4 {
     margin-top: 1.5em;
 }
 
-div.documentwrapper > div.bodywrapper {
+div.bodywrapper {
     margin-left: 260px;
 }
 
@@ -496,7 +496,7 @@ div.genindex-jumpbox a {
         margin-inline-end: 0;
     }
     /* Remove sidebar and top related bar */
-    div.related, .sphinxsidebar {
+    div.related, div.sphinxsidebar {
         display: none;
     }
     /* Anchorlinks are not hidden by fixed-positioned navbar when scrolled to */

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -141,7 +141,7 @@ span.pre {
 
 div.sphinxsidebar {
     display: flex;
-    width: 260px;
+    width: min(25vw, 350px);
     float: none;
     position: sticky;
     top: 0;
@@ -159,7 +159,7 @@ div.sphinxsidebar h4 {
 }
 
 div.bodywrapper {
-    margin-left: 260px;
+    margin-left: min(25vw, 350px);
 }
 
 div.sphinxsidebarwrapper {


### PR DESCRIPTION
Related issue: https://github.com/python/python-docs-theme/issues/209

This is a less disruptive version of https://github.com/python/python-docs-theme/pull/214
This simply increases the width of the sidebar to 260px (not set in stone, happy to discuss the appropriate value)

Two more things I considered that we could discuss but didn't include in the PR
- Adding another breakpoint beyond 1024px which would further increase the sidebar width (not sure if static breakpoints are the way to go though)
- Making the sidebar more flexible by only defining min/max-width and letting the contents determine the exact value. This would require a larger change to the CSS as the sidebar is currently static (it relies on a fixed margin on `.bodywrapper`). Though we could convert it to flexbox as well.

Feedback welcome!


<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--218.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->