### PR TITLE
Horizontally align the collapse button icon

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -191,6 +191,9 @@ div.sphinxsidebar input[type='text'] {
 }
 
 #sidebarbutton {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     /* Sphinx 4.x and earlier compat */
     height: 100%;
     background-color: #CCCCCC;
@@ -200,17 +203,10 @@ div.sphinxsidebar input[type='text'] {
     cursor: pointer;
     padding-top: 1px;
     float: right;
-    display: table;
     /* after Sphinx 4.x and earlier is dropped, only the below is needed */
     width: 12px;
     border-radius: 0 5px 5px 0;
     border-left: none;
-}
-
-#sidebarbutton span {
-    /* Sphinx 4.x and earlier compat */
-    display: table-cell;
-    vertical-align: middle;
 }
 
 #sidebarbutton:hover {


### PR DESCRIPTION
Just something that was bugging me a bit :D I hope this won't be an issue regarding 4.x compatibility?

Before
![image](https://github.com/user-attachments/assets/a9ec749b-93fc-4b52-9a5f-829c686798c0)

After
![image](https://github.com/user-attachments/assets/da133f2b-6de6-458d-9464-9619c15add87)


<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--219.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->