### PR TITLE
Prepare 2025.2 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+`2025.2 <https://github.com/python/python-docs-theme/releases/tag/2025.2>`_
+---------------------------------------------------------------------------
+
+- Note minimum requirements for Sphinx (#216)
+    Contributed by Adam Turner
+- Horizontally centre the sidebar collapse button (#219)
+    Contributed by Tomas Roun
+- Make sidebar width more flexible (#218)
+    Contributed by Tomas Roun
+- Set ``__version__`` in the runtime package (#222)
+    Contributed by Adam Turner
+
 `2024.12 <https://github.com/python/python-docs-theme/releases/tag/2024.12>`_
 -----------------------------------------------------------------------------
 

--- a/python_docs_theme/__init__.py
+++ b/python_docs_theme/__init__.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.util.typing import ExtensionMetadata
 
-__version__ = "2024.12"
+__version__ = "2025.2"
 
 THEME_PATH = Path(__file__).resolve().parent
 


### PR DESCRIPTION
Per https://github.com/python/python-docs-theme/pull/221#pullrequestreview-2590721115

> it might be nice to get https://github.com/python/python-docs-theme/pull/218 merged and released in 2025.2, and then pinning 3.11 to 2025.2?

A

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--223.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->