### PR TITLE
Move locales dir

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
           pip install -r requirements.txt
       - name: Remove locale file for testing
         shell: bash
-        run: rm -rf locales/pt_BR/
+        run: rm -rf python_docs_theme/locales/pt_BR/
       - run: python babel_runner.py extract
       - run: python babel_runner.py init -l pt_BR
       - run: python babel_runner.py update
@@ -79,10 +79,10 @@ jobs:
       - run: python babel_runner.py compile -l pt_BR
       - name: Print .pot file
         shell: bash
-        run: cat locales/messages.pot
+        run: cat python_docs_theme/locales/messages.pot
       - name: Print .po file
         shell: bash
-        run: cat locales/pt_BR/LC_MESSAGES/messages.po
+        run: cat python_docs_theme/locales/pt_BR/LC_MESSAGES/messages.po
       - name: list files in locales dir
         shell: bash
-        run: ls -R locales/
+        run: ls -R python_docs_theme/locales/

--- a/babel_runner.py
+++ b/babel_runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/venv python3
+#!/usr/bin/env python3
 """Script for handling translations with Babel"""
 from __future__ import annotations
 
@@ -24,9 +24,9 @@ INIT_PY = PROJECT_DIR / "python_docs_theme" / "__init__.py"
 # Global variables used by pybabel below (paths relative to PROJECT_DIR)
 DOMAIN = "messages"
 COPYRIGHT_HOLDER = "Python Software Foundation"
-LOCALES_DIR = "locales"
-POT_FILE = Path(LOCALES_DIR, f"{DOMAIN}.pot")
 SOURCE_DIR = "python_docs_theme"
+LOCALES_DIR = Path(SOURCE_DIR, "locales")
+POT_FILE = Path(LOCALES_DIR, f"{DOMAIN}.pot")
 MAPPING_FILE = ".babel.cfg"
 
 

--- a/python_docs_theme/locales/pt_BR/LC_MESSAGES/messages.po
+++ b/python_docs_theme/locales/pt_BR/LC_MESSAGES/messages.po
@@ -1,0 +1,113 @@
+# Portuguese (Brazil) translations for python-docs-theme.
+# Copyright (C) 2025 Python Software Foundation
+# This file is distributed under the same license as the python-docs-theme
+# project.
+# Rafael Fontenelle <rafaelff@gnome.org>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: python-docs-theme 2024.6\n"
+"Report-Msgid-Bugs-To: https://github.com/python/python-docs-theme/issues\n"
+"POT-Creation-Date: 2024-08-03 15:53-0300\n"
+"PO-Revision-Date: 2024-08-03 15:53-0300\n"
+"Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
+"Language: pt_BR\n"
+"Language-Team: Brazilian Portuguese\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.15.0\n"
+
+#: python_docs_theme/footerdonate.html:1
+msgid "The Python Software Foundation is a non-profit corporation."
+msgstr "A Python Software Foundation é uma corporação sem fins lucrativos."
+
+#: python_docs_theme/footerdonate.html:2
+msgid "Please donate."
+msgstr "Por favor, doe."
+
+#: python_docs_theme/layout.html:6
+msgid "Navigation"
+msgstr "Navegação"
+
+#: python_docs_theme/layout.html:51 python_docs_theme/layout.html:111
+msgid "Quick search"
+msgstr "Pesquisa rápida"
+
+#: python_docs_theme/layout.html:52 python_docs_theme/layout.html:112
+msgid "Go"
+msgstr "Ir"
+
+#: python_docs_theme/layout.html:60
+msgid "Theme"
+msgstr "Tema"
+
+#: python_docs_theme/layout.html:62
+msgid "Auto"
+msgstr "Auto"
+
+#: python_docs_theme/layout.html:63
+msgid "Light"
+msgstr "Claro"
+
+#: python_docs_theme/layout.html:64
+msgid "Dark"
+msgstr "Escuro"
+
+#: python_docs_theme/layout.html:96
+msgid "Menu"
+msgstr "Menu"
+
+#: python_docs_theme/layout.html:142
+msgid "Copyright"
+msgstr "Copyright"
+
+#: python_docs_theme/layout.html:147
+msgid ""
+"This page is licensed under the Python Software Foundation License "
+"Version 2."
+msgstr ""
+"Esta página está licenciada sob a licença Python Software Foundation "
+"Versão 2."
+
+#: python_docs_theme/layout.html:149
+msgid ""
+"Examples, recipes, and other code in the documentation are additionally "
+"licensed under the Zero Clause BSD License."
+msgstr ""
+"Exemplos, receitas e outros códigos na documentação são adicionalmente "
+"licenciados soba licença Zero Clause BSD."
+
+#: python_docs_theme/layout.html:152
+#, python-format
+msgid ""
+"See <a href=\"%(license_file)s\">History and License</a> for more "
+"information."
+msgstr ""
+"Veja <a href=\"%(license_file)s\">História e licença</a> para mais "
+"informações."
+
+#: python_docs_theme/layout.html:155
+#, python-format
+msgid "Hosted on %(hosted_on)s."
+msgstr "Hospedado por %(hosted_on)s."
+
+#: python_docs_theme/layout.html:163
+#, python-format
+msgid "Last updated on %(last_updated)s."
+msgstr "Última atualizãaço em %(last_updated)s."
+
+#: python_docs_theme/layout.html:166
+#, python-format
+msgid "<a href=\"%(theme_issues_url)s\">Found a bug</a>?"
+msgstr "<a href=\"%(theme_issues_url)s\">Encontrou um bug</a>?"
+
+#: python_docs_theme/layout.html:170
+#, python-format
+msgid ""
+"Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
+"%(sphinx_version)s."
+msgstr ""
+"Criado usando <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
+"%(sphinx_version)s."


### PR DESCRIPTION
Locales directory needs to be inside the package directory to be installed, so changing the script to place translation files inside seems the best choice. I also added Brazilian Portuguese translation to use as tests.

However, I wasn't able to see the translated theme, so I'm placing this as draft and asking for help.

I tried:
1- building the binary translation file (`msgfmt path/to/file.po -o path/to/file.mo`); and then
2- building the doc:

```shell
git clone https://github.com/python/docsbuild-scripts
python ./docsbuild-scripts/build_docs.py --quick --build-root ./build_root --www-root ./www --log-directory ./logs --group "$(id -g)" --skip-cache-invalidation --theme "$(pwd)" --language pt-br --branch 3.13
```

I even can see the binary translation file installed:

```shell
$ find build_root -name messages.mo
build_root/venv-3.13/lib/python3.13/site-packages/python_docs_theme/locales/pt_BR/LC_MESSAGES/messages.mo
```

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--224.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->