### PR TITLE
Add missing i18n for copy button titles

### DIFF
--- a/.babel.cfg
+++ b/.babel.cfg
@@ -1,3 +1,3 @@
-[jinja2: **.html]
-
 [javascript: **.js]
+
+[jinja2: **.html]

--- a/.babel.cfg
+++ b/.babel.cfg
@@ -1,1 +1,3 @@
 [jinja2: **.html]
+
+[javascript: **.js]

--- a/python_docs_theme/static/copybutton.js
+++ b/python_docs_theme/static/copybutton.js
@@ -33,8 +33,8 @@ const loadCopyButton = () => {
     /* Add a [>>>] button in the top-right corner of code samples to hide
      * the >>> and ... prompts and the output and thus make the code
      * copyable. */
-    const hide_text = "Hide the prompts and output"
-    const show_text = "Show the prompts and output"
+    const hide_text = _("Hide the prompts and output")
+    const show_text = _("Show the prompts and output")
 
     const button = document.createElement("span")
     button.classList.add("copybutton")


### PR DESCRIPTION
Also updates the babel config so that JS files are extracted ;)

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--225.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->