### PR TITLE
Use consistent line-height for light & dark theme

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -328,6 +328,10 @@ tt, code, pre {
     font-size: 96.5%;
 }
 
+pre {
+    line-height: 125%;
+}
+
 div.body tt,
 div.body code {
     border-radius: 3px;

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -328,8 +328,8 @@ tt, code, pre {
     font-size: 96.5%;
 }
 
-pre {
-    line-height: 125%;
+div.body pre {
+    line-height: 120%;
 }
 
 div.body tt,


### PR DESCRIPTION
While working on the copy button, I noticed the line height of the `pre` element differs for the light and dark theme. It is set to `120%` for the light theme `125%` for the dark theme, which is not a huge difference but it's better to be consistent.

The reason for the discrepancy is the order in which the css is included in the `<head>`. For the light theme, `classic.css` takes precedence:
![Screenshot from 2025-04-08 22-31-31](https://github.com/user-attachments/assets/bd1833ae-31de-4ef5-9836-e13850f11ffd)

Whereas for the dark theme, it is `pygments_dark.css` which is the last stylesheet in the `<head>`:
![Screenshot from 2025-04-08 22-31-41](https://github.com/user-attachments/assets/adfec0cd-23ce-46aa-85f5-903d27f0cf9c)

This seems to be related to how sphinx inserts the css for pygments:
https://github.com/sphinx-doc/sphinx/blob/a6d7ae16739bf92a032a7c4df0297db7cf120ec9/sphinx/builders/html/__init__.py#L258-L262

In any case, we can fix this by simply setting the line height in `pydoctheme.css`.

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--227.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->