### PR TITLE
Use the correct spelling of the ``--languages`` flag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
           --group "$(id -g)"
           --skip-cache-invalidation
           --theme "$(pwd)"
-          --language en
+          --languages en
           --branch ${{ matrix.branch }}
       - name: Show logs
         if: failure()


### PR DESCRIPTION


<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--228.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->