### PR TITLE
Add a copy button to code samples

### DIFF
--- a/python_docs_theme/static/copybutton.js
+++ b/python_docs_theme/static/copybutton.js
@@ -34,14 +34,14 @@ const loadCopyButton = () => {
         let timeout = null
         // define the behavior of the button when it's clicked
         return event => {
-          clearTimeout(timeout)
-          const buttonEl = event.currentTarget
-          const codeEl = buttonEl.nextElementSibling
-          navigator.clipboard.writeText(getCopyableText(codeEl))
-          buttonEl.innerText = _("Copied!")
-          timeout = setTimeout(() => {
-              buttonEl.innerText = _("Copy")
-          }, 1500)
+            clearTimeout(timeout)
+            const buttonEl = event.currentTarget
+            const codeEl = buttonEl.nextElementSibling
+            navigator.clipboard.writeText(getCopyableText(codeEl))
+            buttonEl.innerText = _("Copied!")
+            timeout = setTimeout(() => {
+                buttonEl.innerText = _("Copy")
+            }, 1500)
         }
     }
 

--- a/python_docs_theme/static/copybutton.js
+++ b/python_docs_theme/static/copybutton.js
@@ -33,11 +33,23 @@ const loadCopyButton = () => {
     const makeOnButtonClick = () => {
         let timeout = null
         // define the behavior of the button when it's clicked
-        return event => {
+        return async event => {
+            // check if the clipboard is available
+            if (!navigator.clipboard || !navigator.clipboard.writeText) {
+                return;
+            }
+
             clearTimeout(timeout)
             const buttonEl = event.currentTarget
             const codeEl = buttonEl.nextElementSibling
-            navigator.clipboard.writeText(getCopyableText(codeEl))
+
+            try {
+                await navigator.clipboard.writeText(getCopyableText(codeEl))
+            } catch (e) {
+                console.error(e.message)
+                return
+            }
+
             buttonEl.innerText = _("Copied!")
             timeout = setTimeout(() => {
                 buttonEl.innerText = _("Copy")

--- a/python_docs_theme/static/copybutton.js
+++ b/python_docs_theme/static/copybutton.js
@@ -1,65 +1,47 @@
-// ``function*`` denotes a generator in JavaScript, see
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*
-function* getHideableCopyButtonElements(rootElement) {
-    // yield all elements with the "go" (Generic.Output),
-    // "gp" (Generic.Prompt), or "gt" (Generic.Traceback) CSS class
-    for (const el of rootElement.querySelectorAll('.go, .gp, .gt')) {
-        yield el
-    }
-    // tracebacks (.gt) contain bare text elements that need to be
-    // wrapped in a span to hide or show the element
-    for (let el of rootElement.querySelectorAll('.gt')) {
-        while ((el = el.nextSibling) && el.nodeType !== Node.DOCUMENT_NODE) {
-            // stop wrapping text nodes when we hit the next output or
-            // prompt element
-            if (el.nodeType === Node.ELEMENT_NODE && el.matches(".gp, .go")) {
-                break
-            }
-            // if the node is a text node with content, wrap it in a
-            // span element so that we can control visibility
-            if (el.nodeType === Node.TEXT_NODE && el.textContent.trim()) {
-                const wrapper = document.createElement("span")
-                el.after(wrapper)
-                wrapper.appendChild(el)
-                el = wrapper
-            }
-            yield el
+// Extract copyable text from the code block ignoring the
+// prompts and output.
+function getCopyableText(rootElement) {
+    rootElement = rootElement.cloneNode(true)
+    // tracebacks (.gt) contain bare text elements that
+    // need to be removed
+    const tracebacks = rootElement.querySelectorAll(".gt")
+    for (const el of tracebacks) {
+        while (
+            el.nextSibling &&
+            (el.nextSibling.nodeType !== Node.DOCUMENT_NODE ||
+                !el.nextSibling.matches(".gp, .go"))
+        ) {
+            el.nextSibling.remove()
         }
     }
+    // Remove all elements with the "go" (Generic.Output),
+    // "gp" (Generic.Prompt), or "gt" (Generic.Traceback) CSS class
+    const elements = rootElement.querySelectorAll(".gp, .go, .gt")
+    for (const el of elements) {
+        el.remove()
+    }
+    return rootElement.innerText.trim()
 }
 
-
 const loadCopyButton = () => {
-    /* Add a [>>>] button in the top-right corner of code samples to hide
-     * the >>> and ... prompts and the output and thus make the code
-     * copyable. */
-    const hide_text = _("Hide the prompts and output")
-    const show_text = _("Show the prompts and output")
-
-    const button = document.createElement("span")
+    const button = document.createElement("button")
     button.classList.add("copybutton")
-    button.innerText = ">>>"
-    button.title = hide_text
-    button.dataset.hidden = "false"
-    const buttonClick = event => {
+    button.type = "button"
+    button.innerText = _("Copy")
+    button.title = _("Copy to clipboard")
+
+    const makeOnButtonClick = () => {
+        let timeout = null
         // define the behavior of the button when it's clicked
-        event.preventDefault()
-        const buttonEl = event.currentTarget
-        const codeEl = buttonEl.nextElementSibling
-        if (buttonEl.dataset.hidden === "false") {
-            // hide the code output
-            for (const el of getHideableCopyButtonElements(codeEl)) {
-                el.hidden = true
-            }
-            buttonEl.title = show_text
-            buttonEl.dataset.hidden = "true"
-        } else {
-            // show the code output
-            for (const el of getHideableCopyButtonElements(codeEl)) {
-                el.hidden = false
-            }
-            buttonEl.title = hide_text
-            buttonEl.dataset.hidden = "false"
+        return event => {
+          clearTimeout(timeout)
+          const buttonEl = event.currentTarget
+          const codeEl = buttonEl.nextElementSibling
+          navigator.clipboard.writeText(getCopyableText(codeEl))
+          buttonEl.innerText = _("Copied!")
+          timeout = setTimeout(() => {
+              buttonEl.innerText = _("Copy")
+          }, 1500)
         }
     }
 
@@ -78,10 +60,8 @@ const loadCopyButton = () => {
         // if we find a console prompt (.gp), prepend the (deeply cloned) button
         const clonedButton = button.cloneNode(true)
         // the onclick attribute is not cloned, set it on the new element
-        clonedButton.onclick = buttonClick
-        if (el.querySelector(".gp") !== null) {
-            el.prepend(clonedButton)
-        }
+        clonedButton.onclick = makeOnButtonClick()
+        el.prepend(clonedButton)
     })
 }
 

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -442,17 +442,23 @@ div.genindex-jumpbox a {
     top: 0;
     right: 0;
     font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;
-    padding-left: 0.2em;
-    padding-right: 0.2em;
+    font-size: 80%;
+    padding-left: .5em;
+    padding-right: .5em;
+    height: 100%;
+    max-height: min(100%, 2.4em);
     border-radius: 0 3px 0 0;
-    color: #ac9; /* follows div.body pre */
-    border-color: #ac9; /* follows div.body pre */
-    border-style: solid; /* follows div.body pre */
-    border-width: 1px; /* follows div.body pre */
+    color: #000;
+    background-color: #fff;
+    border: 1px solid #ac9; /* follows div.body pre */
 }
 
-.copybutton[data-hidden='true'] {
-    text-decoration: line-through;
+.copybutton:hover {
+    background-color: #eee;
+}
+
+.copybutton:active {
+    background-color: #ddd;
 }
 
 @media (max-width: 1023px) {

--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -176,3 +176,16 @@ img.invert-in-dark-mode {
     --versionchanged: var(--middle-color);
     --deprecated: var(--bad-color);
 }
+
+.copybutton {
+    color: #ac9; /* follows div.body pre */
+    background-color: #222222; /* follows body */
+}
+
+.copybutton:hover {
+    background-color: #434343;
+}
+
+.copybutton:active {
+    background-color: #656565;
+}


### PR DESCRIPTION
I kept the style similar to the previous button. For now it's text but maybe we could use an icon instead?
Note that unlike the previous button, I added the copy button to all code samples, not only the interactive ones.

I'd like to know what you think!

Before:
![image](https://github.com/user-attachments/assets/0ec9adc0-0605-4fa2-8d3d-65c808990876)

After:
![image](https://github.com/user-attachments/assets/ecd4ffb8-71d0-43a7-ab9c-8403bdbd98dd)
![image](https://github.com/user-attachments/assets/754903b3-56d2-4d8c-a4b6-da1dbcfa1a00)

Single line:
![image](https://github.com/user-attachments/assets/c7cb13ff-a211-4ed8-a247-db07cf40ef11)
![image](https://github.com/user-attachments/assets/9975069d-9d3d-492f-8129-a11bc7a582c9)

[copybtn.webm](https://github.com/user-attachments/assets/b955f7b2-17e0-4b07-8ed8-74380450c4fd)


<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--231.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->