### PR TITLE
CI: Use `--branches` for docsbuild-scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
           --skip-cache-invalidation
           --theme "$(pwd)"
           --languages en
-          --branch ${{ matrix.branch }}
+          --branches ${{ matrix.branch }}
       - name: Show logs
         if: failure()
         run: |


### PR DESCRIPTION
`--branch` was replaced with `--branches` in https://github.com/python/docsbuild-scripts/pull/235.

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--232.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->