### PR TITLE
Drop support for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ["origin/main", "3.13", "3.12", "3.11", "3.10"]
+        branch: ["origin/main", "3.13", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -56,7 +56,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         # Test minimum supported and latest stable from 3.x series
-        python-version: ["3.10", "3"]
+        python-version: ["3.12", "3"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/babel_runner.py
+++ b/babel_runner.py
@@ -5,17 +5,8 @@ from __future__ import annotations
 import argparse
 import ast
 import subprocess
+import tomllib
 from pathlib import Path
-
-try:
-    import tomllib
-except ImportError:
-    try:
-        import tomli as tomllib
-    except ImportError as ie:
-        raise ImportError(
-            "tomli or tomllib is required to parse pyproject.toml"
-        ) from ie
 
 PROJECT_DIR = Path(__file__).resolve().parent
 PYPROJECT_TOML = PROJECT_DIR / "pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "The Sphinx theme for the CPython docs and related projects"
 readme = "README.md"
 license.file = "LICENSE"
 authors = [ { name = "PyPA", email = "distutils-sig@python.org" } ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Sphinx :: Theme",
@@ -19,8 +19,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Topic :: Documentation",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 # for babel_runner.py
-setuptools
 Babel
 Jinja2
-tomli; python_version < "3.11"


### PR DESCRIPTION
Fixes https://github.com/python/python-docs-theme/issues/233.

3.10 and 3.11 are pinned and won't get further backports: [python/cpython@`3.11`/Doc/requirements.txt](https://github.com/python/cpython/blob/3.11/Doc/requirements.txt?rgh-link-date=2025-04-18T19%3A33%3A00.000Z)



<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--234.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->