### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3
+          python-version: ${{ matrix.branch == 'origin/main' && '3.14' || matrix.branch }}
           allow-prereleases: true
           cache: pip
       - name: Clone docsbuild scripts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
           --theme "$(pwd)"
           --languages en
           --branches ${{ matrix.branch }}
+          ${{ matrix.branch == '3.14' && '--select-output no-html' || '' }}
       - name: Show logs
         if: failure()
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ["origin/main", "3.13", "3.12"]
+        branch: ["3.14", "3.13", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.branch == 'origin/main' && '3.14' || matrix.branch }}
+          python-version: ${{ matrix.branch }}
           allow-prereleases: true
           cache: pip
       - name: Clone docsbuild scripts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,6 @@ repos:
     rev: v2.5.0
     hooks:
       - id: pyproject-fmt
-        args: [--max-supported-python=3.13]
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.23

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Documentation",
   "Topic :: Software Development :: Documentation",
 ]
@@ -67,3 +68,6 @@ lint.ignore = [
   "E241", # Multiple spaces after ','
 ]
 lint.isort.required-imports = [ "from __future__ import annotations" ]
+
+[tool.pyproject-fmt]
+max_supported_python = "3.14"


### PR DESCRIPTION
Also test building the CPython branches on the corresponding versions.

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--236.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->