### PR TITLE
Replace deprecated classifier with licence expression (PEP 639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,14 @@ requires = [
 name = "python-docs-theme"
 description = "The Sphinx theme for the CPython docs and related projects"
 readme = "README.md"
-license.file = "LICENSE"
+license = "PSF-2.0"
+license-files = [ "LICENSE" ]
 authors = [ { name = "PyPA", email = "distutils-sig@python.org" } ]
 requires-python = ">=3.12"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Sphinx :: Theme",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Python Software Foundation License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
See https://hugovk.dev/blog/2025/improving-licence-metadata/

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--237.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->