### PR TITLE
Fix copy button with multiple tracebacks

### DIFF
--- a/python_docs_theme/static/copybutton.js
+++ b/python_docs_theme/static/copybutton.js
@@ -8,7 +8,7 @@ function getCopyableText(rootElement) {
     for (const el of tracebacks) {
         while (
             el.nextSibling &&
-            (el.nextSibling.nodeType !== Node.DOCUMENT_NODE ||
+            (el.nextSibling.nodeType !== Node.ELEMENT_NODE ||
                 !el.nextSibling.matches(".gp, .go"))
         ) {
             el.nextSibling.remove()


### PR DESCRIPTION
The copy button currently removes everything after a traceback, including code that should be copied: https://docs.python.org/3.14/whatsnew/3.14.html#improved-error-messages