### PR TITLE
Make the copy button only appear when hovered over or clicked on

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -451,6 +451,7 @@ div.genindex-jumpbox a {
     color: #000;
     background-color: #fff;
     border: 1px solid #ac9; /* follows div.body pre */
+    display: none;
 }
 
 .copybutton:hover {
@@ -459,6 +460,14 @@ div.genindex-jumpbox a {
 
 .copybutton:active {
     background-color: #ddd;
+}
+
+.highlight:active .copybutton {
+    display: block;
+}
+
+.highlight:hover .copybutton {
+    display: block;
 }
 
 @media (max-width: 1023px) {


### PR DESCRIPTION
- Made the copy button only appear when hovered over or clicked on
- Tested on chrome, arc, safari and mobile devices

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--243.org.readthedocs.build/en/243/library/string.html#module-string

<!-- readthedocs-preview python-docs-theme-previews end -->