### PR TITLE
Remove 'navigation'

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -3,7 +3,6 @@
 {%- macro relbar() %}
 {# modified from sphinx/themes/basic/layout.html #}
     <div class="related" role="navigation" aria-label="related navigation">
-      <h3>{{ _('Navigation') }}</h3>
       <ul>
           {%- for rellink in rellinks %}
           <li class="right" {% if loop.first %}style="margin-right: 10px"{% endif %}>


### PR DESCRIPTION
I found this in Transifex. This is not displayed. (e.g. `display: none`).

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--258.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->