### PR TITLE
Strech search button to text width

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 CPYTHON_PATH = ../cpython
 PYTHON       = python3
 PACKAGE_ABS_PATH = $(shell pwd)/$(shell find dist/python-docs-theme-*.tar.gz)
+SPNINXOPTS       ?=
 
 
 .PHONY: help
@@ -22,7 +23,7 @@ venv:
 .PHONY: html
 html: venv
 	cd $(CPYTHON_PATH)/Doc && \
-		make html
+		make SPHINXOPTS="$(SPHINXOPTS)" html
 
 .PHONY: htmlview
 htmlview: html

--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -123,7 +123,9 @@ form.inline-search input {
 }
 
 form.inline-search input[type='submit'] {
-    width: 40px;
+    /* In some languages, more than 40px is required */
+    width: auto;
+    min-width: 40px;
 }
 
 div.document {


### PR DESCRIPTION
Current behavior (`40 px` width) is preserved when possible:

<img width="837" height="88" alt="image" src="https://github.com/user-attachments/assets/2986b8d1-415c-4dde-b10e-144700c94588" />

In the case of longer text, which is currently cut off:

<img width="837" height="88" alt="image" src="https://github.com/user-attachments/assets/39359da6-a72f-477f-8c6a-974f9ff6e1d2" />

With this PR, it can expand:

<img width="837" height="88" alt="image" src="https://github.com/user-attachments/assets/9e849aeb-5129-40e5-a612-44ae728a6e0a" />


> [!NOTE] 
> Also included in this PR is an ease of development improvement Makefile, for building a translation. I do not think it is particularly important to give it its' own PR, but I can do that if necessary.


