### PR TITLE
Remove trailing space from link

### DIFF
--- a/python_docs_theme/layout.html
+++ b/python_docs_theme/layout.html
@@ -137,12 +137,12 @@
 {% block footer %}
     <div class="footer">
     &copy; {% if theme_copyright_url or hasdoc('copyright') -%}
-        <a href="{% if theme_copyright_url %}{{ theme_copyright_url }}{% else %}{{ pathto('copyright') }}{% endif %}">
-      {%- endif -%}
-      {%- trans -%}Copyright{%- endtrans -%}
-      {%- if theme_copyright_url or hasdoc('copyright') -%}
-      </a>
-      {%- endif %} {{ copyright|e }}.
+      <a href="{% if theme_copyright_url %}{{ theme_copyright_url }}{% else %}{{ pathto('copyright') }}{% endif %}">
+    {%- endif -%}
+    {%- trans %}Copyright{% endtrans -%}
+    {%- if theme_copyright_url or hasdoc('copyright') -%}
+    </a>
+    {%- endif %} {{ copyright|e }}.
     <br>
     {% trans %}This page is licensed under the Python Software Foundation License Version 2.{% endtrans %}
     <br>


### PR DESCRIPTION
Current:
<img width="589" height="49" alt="image" src="https://github.com/user-attachments/assets/fcd7bca3-e327-4797-9a4a-6a507b3d833a" />

With PR:
<img width="589" height="49" alt="image" src="https://github.com/user-attachments/assets/e6d4a0c7-7daf-4ae0-972d-c4be64efd97b" />


<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--269.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->