### PR TITLE
Add support for Python 3.15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ["3.14", "3.13", "3.12"]
+        python-version: ["3.15", "3.14", "3.13", "3.12"]
+        include:
+          - python-version: "3.15"
+            branch: "main"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.branch }}
+          python-version: ${{ matrix.python-version }}
           allow-prereleases: true
           cache: pip
       - name: Clone docsbuild scripts
@@ -38,8 +41,8 @@ jobs:
           --skip-cache-invalidation
           --theme "$(pwd)"
           --languages en
-          --branches ${{ matrix.branch }}
-          ${{ matrix.branch == '3.14' && '--select-output no-html' || '' }}
+          --branches ${{ matrix.branch || matrix.python-version }}
+          ${{ matrix.branch == 'main' && '--select-output no-html' || '' }}
       - name: Show logs
         if: failure()
         run: |
@@ -47,7 +50,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v5
         with:
-          name: doc-html-${{ matrix.branch }}
+          name: doc-html-${{ matrix.python-version }}
           path: www/
 
   translations:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Documentation",
   "Topic :: Software Development :: Documentation",
 ]
@@ -70,4 +71,4 @@ lint.ignore = [
 lint.isort.required-imports = [ "from __future__ import annotations" ]
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
+max_supported_python = "3.15"


### PR DESCRIPTION
The earlier approach was something like:
```yml
      matrix:
        branch: ["main", "3.14", "3.13", "3.12"]
...
          python-version: ${{ matrix.branch == 'main' && '3.15' || matrix.branch }}
...
          --branches ${{ matrix.branch }}
```
Which do you prefer?

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--282.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->