### PR TITLE
Add green, red and yellow side borders for code examples

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -235,6 +235,18 @@ div.body pre {
     border: 1px solid #ac9;
 }
 
+div.body {
+    .good pre {
+        border-left: 3px solid var(--good-border);
+    }
+    .bad pre {
+        border-left: 3px solid var(--bad-border);
+    }
+    .maybe pre {
+        border-left: 3px solid var(--middle-border);
+    }
+}
+
 /* Admonitions */
 :root {
     --admonition-background: #eee;


### PR DESCRIPTION
Like https://github.com/python/peps/pull/3567 and https://github.com/python/devguide/pull/1237, re: https://github.com/python/docs-community/issues/22.

This will allow us to add borders on the left side of code examples to flag if they're "good", "bad", or somewhere in between.

For example:

```rst
Do this:

.. code-block::
   :class: good

   a = 1

Don't do this:

.. code-block::
   :class: bad

    a =

Take care doing this:

.. code-block::
   :class: maybe

    a = 2
```

Gives:

<img width="490" height="234" alt="image" src="https://github.com/user-attachments/assets/7f799b7b-1778-4193-b737-7b2556311073" /> <img width="487" height="240" alt="image" src="https://github.com/user-attachments/assets/a9c45b77-afc9-4d41-b561-08e62debec08" />

And this will be useful for the upcoming free-threaded guidance coming to the docs.

cc @lysnikolaou 



<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--285.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->