### PR TITLE
Add styling rule to field-list for vertical alignment

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -426,6 +426,10 @@ div.footer a:hover {
     color: #0095c4;
 }
 
+dl.field-list > dt {
+    align-self: center;
+}
+
 /* C API return value annotations */
 :root {
     --refcount: var(--good-color);

--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -77,6 +77,7 @@ span.highlighted {
 /* Below for most things in text */
 
 dl.field-list > dt {
+    align-self: center;
     background-color: #434;
 }
 


### PR DESCRIPTION
Fixes #289 

# Before
<img width="835" height="306" alt="Before" src="https://github.com/user-attachments/assets/1ca0767b-a93d-45ba-a462-b7bf15d569e8" />

# After
<img width="835" height="306" alt="After" src="https://github.com/user-attachments/assets/9df76199-c391-4d29-823f-2703a7f5e8bd" />

<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--296.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->