### PR TITLE
Set line-height on field-list term

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -223,6 +223,9 @@ div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6 {
     border: 0;
     padding: 0.3em 0;
 }
+div.body dl.field-list > dt {
+    line-height: 1.6;
+}
 
 div.body hr {
     border: 0;


### PR DESCRIPTION
Fixes #289, by making a targeted change
Closes #296, by resolving the underlying issue

| Before | After |
| --- | --- |
| <img width="383" height="98" alt="Screenshot 2026-04-14 at 11 00 56" src="https://github.com/user-attachments/assets/ed40a71f-e719-411b-a11e-2d23b848b946" /> | <img width="383" height="98" alt="Screenshot 2026-04-14 at 11 00 54" src="https://github.com/user-attachments/assets/b670dace-8c01-4304-80e0-34a5729fe201" /> |
| <img width="792" height="318" alt="Screenshot 2026-04-14 at 11 07 50" src="https://github.com/user-attachments/assets/f579a595-1724-4f84-b65c-12dce9a63155" /> | <img width="792" height="318" alt="Screenshot 2026-04-14 at 11 07 47" src="https://github.com/user-attachments/assets/3766b805-1cf4-4284-8f3a-5c97254fe212" /> |


<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--303.org.readthedocs.build/

<!-- readthedocs-preview python-docs-theme-previews end -->