### PR TITLE
Add styling for `soft-deprecated` class

### DIFF
--- a/python_docs_theme/static/pydoctheme.css
+++ b/python_docs_theme/static/pydoctheme.css
@@ -789,10 +789,12 @@ div.genindex-jumpbox a {
     --versionadded: var(--good-color);
     --versionchanged: var(--middle-color);
     --deprecated: var(--bad-color);
+    --soft-deprecated: rgb(175, 0, 255);
 
     --versionadded-border: var(--good-border);
     --versionchanged-border: var(--middle-border);
     --deprecated-border: var(--bad-border);
+    --soft-deprecated-border: rgb(175, 0, 255);
 }
 
 div.versionadded,
@@ -817,6 +819,10 @@ div.versionremoved {
     border-left-color: var(--deprecated-border);
 }
 
+div.soft-deprecated {
+    border-left-color: var(--soft-deprecated-border);
+}
+
 div.versionadded .versionmodified {
     color: var(--versionadded);
 }
@@ -829,6 +835,10 @@ div.deprecated .versionmodified,
 div.deprecated-removed .versionmodified,
 div.versionremoved .versionmodified {
     color: var(--deprecated);
+}
+
+div.soft-deprecated .versionmodified {
+    color: var(--soft-deprecated);
 }
 
 /* Hide header when printing */

--- a/python_docs_theme/static/pydoctheme_dark.css
+++ b/python_docs_theme/static/pydoctheme_dark.css
@@ -181,6 +181,8 @@ img.invert-in-dark-mode {
     --versionadded: var(--good-color);
     --versionchanged: var(--middle-color);
     --deprecated: var(--bad-color);
+    --soft-deprecated: rgb(206, 100, 255);
+    --soft-deprecated-border: rgb(206, 100, 255);
 }
 
 .copybutton {


### PR DESCRIPTION
For the new directive proposed in https://github.com/python/cpython/pull/148630. I have to use two separate colours to meet accessibility standards.

In light mode with "Poison Purple Paradise" (per [some site](https://colornamer.robertcooper.me/)), we have a ratio of 4.92:

<img width="1153" height="242" alt="image" src="https://github.com/user-attachments/assets/9b3e0314-3ff4-4d3a-9634-49116b73ab4f" />

In dark mode with "Jacaranda Pink", we have a ratio of 5.22:

<img width="1153" height="242" alt="image" src="https://github.com/user-attachments/assets/d9dfb782-73f0-4dbf-adbb-0fc29096014d" />


<!-- readthedocs-preview python-docs-theme-previews start -->
----
📚 Documentation preview 📚: https://python-docs-theme-previews--305.org.readthedocs.build/en/305/library/re.html#re.match

<!-- readthedocs-preview python-docs-theme-previews end -->