### PR TITLE
Remove old zizmor config file

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,0 @@
-# Configuration for the zizmor static analysis tool, run via prek in CI
-# https://docs.zizmor.sh/configuration/
-rules:
-  dangerous-triggers:
-    ignore:
-      - documentation-links.yml


### PR DESCRIPTION
No longer need to ignore any rules after removing `documentation-links.yml` in https://github.com/python/python-docs-theme/pull/308.