### PR TITLE
Fix install from sdist for RTD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # You can set these variables from the command line.
 CPYTHON_PATH = ../cpython
 PYTHON       = python3
-PACKAGE_ABS_PATH = $(shell pwd)/$(shell find dist/python-docs-theme-*.tar.gz)
 SPHINXOPTS   =
 
 
@@ -15,10 +14,11 @@ help:
 .PHONY: venv
 venv:
 	$(PYTHON) -m pip install build
+	rm -rf dist/
 	$(PYTHON) -m build
 	cd $(CPYTHON_PATH)/Doc \
 		&& make venv \
-		&& ./venv/bin/pip install $(PACKAGE_ABS_PATH)
+		&& ./venv/bin/pip install $(CURDIR)/dist/python_docs_theme-*.tar.gz
 
 .PHONY: html
 html: venv


### PR DESCRIPTION
The `Makefile` wasn't quite working as intended. This is used for RTD builds.

## Before

It intends to build an sdist and then install from that. But:

```
find: ‘dist/python-docs-theme-*.tar.gz’: No such file or directory
```

https://app.readthedocs.org/projects/python-docs-theme-previews/builds/33742569/

This is because the filenames are now normalised and look like `python_docs_theme-2026.4.tar.gz`

But anyway, it was evaluating this before even running `$(PYTHON) -m build`:

```
PACKAGE_ABS_PATH = $(shell pwd)/$(shell find dist/python-docs-theme-*.tar.gz)
```

So even the correct name wouldn't find it.

But it was then installing from PyPI as part of the normal docs build:

```
Collecting python-docs-theme==2026.4 (from pylock.toml)
  Downloading python_docs_theme-2026.4-py3-none-any.whl (73 kB)
```

And then `./venv/bin/pip install $(PACKAGE_ABS_PATH)` was just doing an install from the current directory, so we ended up with the local dev version after all:

```
Building wheels for collected packages: python-docs-theme
  Building wheel for python-docs-theme (pyproject.toml): started
  Building wheel for python-docs-theme (pyproject.toml): finished with status 'done'
  Created wheel for python-docs-theme: filename=python_docs_theme-2026.4-py3-none-any.whl size=47033 sha256=2ef5cfd56d04c28218e833d12a81b068b485bef38818c88da1b99c670bcb2ce3
  Stored in directory: /tmp/pip-ephem-wheel-cache-36pb2g5u/wheels/9c/8a/8b/1187bbb4cb469b4e87f8aee1562b67ba81301f0ababe695fea
Successfully built python-docs-theme
Installing collected packages: python-docs-theme
  Attempting uninstall: python-docs-theme
    Found existing installation: python-docs-theme 2026.4
    Uninstalling python-docs-theme-2026.4:
      Successfully uninstalled python-docs-theme-2026.4
Successfully installed python-docs-theme-2026.4
```

## After

Fix installing from sdist.

Remove `PACKAGE_ABS_PATH` and let the shell expand the normalised glob when pip runs, after the sdist is built. Also clear `dist/` before building, so a stale tarball from a previous build can't make the glob match two files.
